### PR TITLE
feat: Bust service cache on incoming websocket

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -47,7 +47,7 @@ func New(config *rest.Config, refresh time.Duration, consoleUrl, deployToken, cl
 	deathChan := make(chan interface{})
 	invFactory := inventory.ClusterClientFactory{StatusPolicy: inventory.StatusPolicyNone}
 
-	socket, err := websocket.New(clusterId, consoleUrl, deployToken, svcQueue)
+	socket, err := websocket.New(clusterId, consoleUrl, deployToken, svcQueue, svcCache)
 	if err != nil {
 		if socket == nil {
 			return nil, err

--- a/pkg/client/cache.go
+++ b/pkg/client/cache.go
@@ -50,6 +50,10 @@ func (c *ServiceCache) Wipe() {
 	c.cache.Clear()
 }
 
+func (c *ServiceCache) Expire(id string) {
+	c.cache.Remove(id)
+}
+
 func (l *cacheLine) live(dur time.Duration) bool {
 	return l.created.After(time.Now().Add(-dur))
 }


### PR DESCRIPTION
At the moment the websocket might not matter that much, since it would just get served out of cache, we can confidently expire in that case.