### PR TITLE
feat: Avoid version coercion in components

### DIFF
--- a/pkg/manifests/versions.go
+++ b/pkg/manifests/versions.go
@@ -1,0 +1,25 @@
+package manifests
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type GroupName struct {
+	Group string
+	Kind  string
+	Name  string
+}
+
+func VersionCache(manifests []*unstructured.Unstructured) map[GroupName]string {
+	res := map[GroupName]string{}
+	for _, man := range manifests {
+		gvk := man.GroupVersionKind()
+		name := GroupName{
+			Group: gvk.Group,
+			Kind:  gvk.Kind,
+			Name:  man.GetName(),
+		}
+		res[name] = gvk.Version
+	}
+	return res
+}

--- a/pkg/sync/loop.go
+++ b/pkg/sync/loop.go
@@ -6,6 +6,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	manis "github.com/pluralsh/deployment-operator/pkg/manifests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apply"
@@ -110,6 +111,8 @@ func (engine *Engine) processItem(item interface{}) error {
 		})
 		return engine.UpdatePruneStatus(id, svc.Name, svc.Namespace, ch, len(manifests))
 	}
+
+	vcache := manis.VersionCache(manifests)
 	log.Info("Apply service", "name", svc.Name, "namespace", svc.Namespace)
 	if err := engine.CheckNamespace(svc.Namespace); err != nil {
 		log.Error(err, "failed to check namespace")
@@ -137,7 +140,7 @@ func (engine *Engine) processItem(item interface{}) error {
 		InventoryPolicy:        inventory.PolicyAdoptAll,
 	})
 
-	return engine.UpdateApplyStatus(id, svc.Name, svc.Namespace, ch, false)
+	return engine.UpdateApplyStatus(id, svc.Name, svc.Namespace, ch, false, vcache)
 }
 
 func (engine *Engine) splitObjects(id string, objs []*unstructured.Unstructured) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {


### PR DESCRIPTION
Kubernetes will occasionally switch kind versions on apply automatically via mutating webhooks, this is fine, but ruins our ability to detect deprecations in manifests, so revert back to manifest versions where we can find them.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205855554055664