### PR TITLE
feat: Add basic scrapes for runtime services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/osteele/liquid v1.3.2
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console-client-go v0.0.33
+	github.com/pluralsh/console-client-go v0.0.38
 	github.com/pluralsh/gophoenix v0.1.3-0.20231024165338-04291b4de463
 	github.com/pluralsh/polly v0.1.4
 	github.com/samber/lo v1.38.1

--- a/go.sum
+++ b/go.sum
@@ -554,6 +554,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pluralsh/console-client-go v0.0.33 h1:Bmh5CRBIYyb5wfYlrAntqQZ3GduBTUmzJlmCeo4HAWU=
 github.com/pluralsh/console-client-go v0.0.33/go.mod h1:kZjk0pXAWnvyj+miXveCho4kKQaX1Tm3CGAM+iwurWU=
+github.com/pluralsh/console-client-go v0.0.38 h1:Hb5V5pX+6RptVzlV/22uECkkjSngPB6jH2X0QSg5JTw=
+github.com/pluralsh/console-client-go v0.0.38/go.mod h1:kZjk0pXAWnvyj+miXveCho4kKQaX1Tm3CGAM+iwurWU=
 github.com/pluralsh/gophoenix v0.1.3-0.20231024165338-04291b4de463 h1:PtXJG2hM73c98bqYAaFNtY+eJ1RupEArHSarNzi3Hek=
 github.com/pluralsh/gophoenix v0.1.3-0.20231024165338-04291b4de463/go.mod h1:IagWXKFYu6NTHzcJx2dJyrIlZ1Sv2PH3fhOtplA9qOs=
 github.com/pluralsh/polly v0.1.4 h1:Kz90peCgvsfF3ERt8cujr5TR9z4wUlqQE60Eg09ZItY=

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -8,3 +8,15 @@ func (c *Client) Ping(vsn string) error {
 	_, err := c.consoleClient.PingCluster(c.ctx, console.ClusterPing{CurrentVersion: vsn})
 	return err
 }
+
+func (c *Client) RegisterRuntimeServices(svcs map[string]string, serviceId *string) error {
+	inputs := make([]*console.RuntimeServiceAttributes, 0)
+	for name, version := range svcs {
+		inputs = append(inputs, &console.RuntimeServiceAttributes{
+			Name:    name,
+			Version: version,
+		})
+	}
+	_, err := c.consoleClient.RegisterRuntimeServices(c.ctx, inputs, serviceId)
+	return err
+}

--- a/pkg/sync/engine.go
+++ b/pkg/sync/engine.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"github.com/pluralsh/deployment-operator/pkg/client"
 	"github.com/pluralsh/deployment-operator/pkg/manifests"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"time"
 
@@ -14,6 +16,7 @@ import (
 
 type Engine struct {
 	client            *client.Client
+	clientset         *kubernetes.Clientset
 	svcQueue          workqueue.RateLimitingInterface
 	deathChan         chan interface{}
 	svcCache          *client.ServiceCache
@@ -42,6 +45,12 @@ func New(utilFactory util.Factory, invFactory inventory.ClientFactory, applier *
 
 func (engine *Engine) AddHealthCheck(health chan interface{}) {
 	engine.deathChan = health
+}
+
+func (engine *Engine) WithConfig(config *rest.Config) error {
+	cs, err := kubernetes.NewForConfig(config)
+	engine.clientset = cs
+	return err
 }
 
 func (engine *Engine) RegisterHandlers() {}

--- a/pkg/sync/scraper.go
+++ b/pkg/sync/scraper.go
@@ -1,0 +1,56 @@
+package sync
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (engine *Engine) ScrapeKube() {
+	log.Info("attempting to collect all runtime services for the cluster")
+	ctx := context.Background()
+	runtimeServices := map[string]string{}
+	deployments, err := engine.clientset.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		log.Info("aggregating from deployments")
+		for _, deployment := range deployments.Items {
+			AddRuntimeServiceInfo(deployment.GetLabels(), runtimeServices)
+		}
+	}
+
+	statefulSets, err := engine.clientset.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		log.Info("aggregating from statefulsets")
+		for _, ss := range statefulSets.Items {
+			AddRuntimeServiceInfo(ss.GetLabels(), runtimeServices)
+		}
+	}
+
+	daemonSets, err := engine.clientset.AppsV1().DaemonSets("").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		log.Info("aggregating from daemonsets")
+		for _, ss := range daemonSets.Items {
+			AddRuntimeServiceInfo(ss.GetLabels(), runtimeServices)
+		}
+	}
+	if err := engine.client.RegisterRuntimeServices(runtimeServices, nil); err != nil {
+		log.Error(err, "failed to register runtime services, this is an ignorable error but could mean your console needs to be upgraded")
+	}
+}
+
+func AddRuntimeServiceInfo(labels map[string]string, acc map[string]string) {
+	if labels == nil {
+		return
+	}
+
+	if vsn, ok := labels["app.kubernetes.io/version"]; ok {
+		if name, ok := labels["app.kubernetes.io/name"]; ok {
+			acc[name] = vsn
+			return
+		}
+
+		if name, ok := labels["app.kubernetes.io/part-of"]; ok {
+			acc[name] = vsn
+		}
+	}
+}


### PR DESCRIPTION
Most of these are detectable by the app.kubernetes.io/{name,part-of,version} labels.  If there are some others that are atypical we can add clauses as needed.