### PR TITLE
feat: Add expected error handling and some other tweaks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/osteele/liquid v1.3.2
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console-client-go v0.0.48
+	github.com/pluralsh/console-client-go v0.0.49
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.1.4
 	github.com/samber/lo v1.38.1

--- a/go.sum
+++ b/go.sum
@@ -558,6 +558,8 @@ github.com/pluralsh/console-client-go v0.0.38 h1:Hb5V5pX+6RptVzlV/22uECkkjSngPB6
 github.com/pluralsh/console-client-go v0.0.38/go.mod h1:kZjk0pXAWnvyj+miXveCho4kKQaX1Tm3CGAM+iwurWU=
 github.com/pluralsh/console-client-go v0.0.48 h1:J/6IYZdQkZGf4pDPUbodCsdg8pz6EBd9dQ0PDYTqQBQ=
 github.com/pluralsh/console-client-go v0.0.48/go.mod h1:u/RjzXE3wtl3L6wiWxwhQHSpxFX46+EYvpkss2mALN4=
+github.com/pluralsh/console-client-go v0.0.49 h1:ju58KTfdYqxaRNDCKU3w6p19tVHoQRX9+HiNMY5cZqc=
+github.com/pluralsh/console-client-go v0.0.49/go.mod h1:u/RjzXE3wtl3L6wiWxwhQHSpxFX46+EYvpkss2mALN4=
 github.com/pluralsh/gophoenix v0.1.3-0.20231024165338-04291b4de463 h1:PtXJG2hM73c98bqYAaFNtY+eJ1RupEArHSarNzi3Hek=
 github.com/pluralsh/gophoenix v0.1.3-0.20231024165338-04291b4de463/go.mod h1:IagWXKFYu6NTHzcJx2dJyrIlZ1Sv2PH3fhOtplA9qOs=
 github.com/pluralsh/gophoenix v0.1.3-0.20231130185730-05776a7643b6 h1:UiVpDs8L6EGtucWla0XyncEARxkr/bn7vgt4Bysvbzs=

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -26,3 +26,8 @@ func (c *Client) UpdateComponents(id string, components []*console.ComponentAttr
 	_, err := c.consoleClient.UpdateServiceComponents(c.ctx, id, components, errs)
 	return err
 }
+
+func (c *Client) AddServiceErrors(id string, errs []*console.ServiceErrorAttributes) error {
+	_, err := c.consoleClient.AddServiceError(c.ctx, id, errs)
+	return err
+}

--- a/pkg/errors/base.go
+++ b/pkg/errors/base.go
@@ -4,4 +4,4 @@ import (
 	"errors"
 )
 
-var ExpectedError = errors.New("this is a transient, expected error")
+var ErrExpected = errors.New("this is a transient, expected error")

--- a/pkg/errors/base.go
+++ b/pkg/errors/base.go
@@ -1,0 +1,7 @@
+package errors
+
+import (
+	"errors"
+)
+
+var ExpectedError = errors.New("This is a transient, expected error")

--- a/pkg/errors/base.go
+++ b/pkg/errors/base.go
@@ -4,4 +4,4 @@ import (
 	"errors"
 )
 
-var ExpectedError = errors.New("This is a transient, expected error")
+var ExpectedError = errors.New("this is a transient, expected error")

--- a/pkg/errors/manifests.go
+++ b/pkg/errors/manifests.go
@@ -1,0 +1,8 @@
+package errors
+
+import (
+	"fmt"
+)
+
+var UnauthenticatedError = fmt.Errorf("This agent cannot access the plural api", ExpectedError)
+var TransientManifestError = fmt.Errorf("This is a temporary api error", ExpectedError)

--- a/pkg/errors/manifests.go
+++ b/pkg/errors/manifests.go
@@ -4,5 +4,5 @@ import (
 	"fmt"
 )
 
-var UnauthenticatedError = fmt.Errorf("This agent cannot access the plural api", ExpectedError)
-var TransientManifestError = fmt.Errorf("This is a temporary api error", ExpectedError)
+var UnauthenticatedError = fmt.Errorf("This agent cannot access the plural api, %w", ExpectedError)
+var TransientManifestError = fmt.Errorf("This is a temporary api error, %w", ExpectedError)

--- a/pkg/errors/manifests.go
+++ b/pkg/errors/manifests.go
@@ -4,5 +4,5 @@ import (
 	"fmt"
 )
 
-var UnauthenticatedError = fmt.Errorf("This agent cannot access the plural api, %w", ExpectedError)
-var TransientManifestError = fmt.Errorf("This is a temporary api error, %w", ExpectedError)
+var ErrUnauthenticated = fmt.Errorf("This agent cannot access the plural api, %w", ErrExpected)
+var ErrTransientManifest = fmt.Errorf("This is a temporary api error, %w", ErrExpected)

--- a/pkg/manifests/tarball.go
+++ b/pkg/manifests/tarball.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pluralsh/deployment-operator/pkg/errors"
 	"github.com/pluralsh/polly/fs"
 )
 
@@ -32,6 +33,14 @@ func fetch(url, token string) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
+		if resp.StatusCode == 403 {
+			return dir, errors.UnauthenticatedError
+		}
+
+		if resp.StatusCode == 402 {
+			return dir, errors.TransientManifestError
+		}
+
 		return dir, fmt.Errorf("could not fetch manifest, error code %d", resp.StatusCode)
 	}
 

--- a/pkg/manifests/tarball.go
+++ b/pkg/manifests/tarball.go
@@ -34,11 +34,11 @@ func fetch(url, token string) (string, error) {
 
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 403 {
-			return dir, errors.UnauthenticatedError
+			return dir, errors.ErrUnauthenticated
 		}
 
 		if resp.StatusCode == 402 {
-			return dir, errors.TransientManifestError
+			return dir, errors.ErrTransientManifest
 		}
 
 		return dir, fmt.Errorf("could not fetch manifest, error code %d", resp.StatusCode)

--- a/pkg/sync/loop.go
+++ b/pkg/sync/loop.go
@@ -51,7 +51,7 @@ func (engine *Engine) workerLoop() {
 		if err != nil {
 			log.Error(err, "process item")
 			id := item.(string)
-			if id != "" && !errors.Is(err, plrlerrors.ExpectedError) {
+			if id != "" && !errors.Is(err, plrlerrors.ErrExpected) {
 				engine.UpdateErrorStatus(id, err)
 			}
 		}

--- a/pkg/sync/loop.go
+++ b/pkg/sync/loop.go
@@ -2,10 +2,12 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"time"
 
+	plrlerrors "github.com/pluralsh/deployment-operator/pkg/errors"
 	manis "github.com/pluralsh/deployment-operator/pkg/manifests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -49,7 +51,7 @@ func (engine *Engine) workerLoop() {
 		if err != nil {
 			log.Error(err, "process item")
 			id := item.(string)
-			if id != "" {
+			if id != "" && !errors.Is(err, plrlerrors.ExpectedError) {
 				engine.UpdateErrorStatus(id, err)
 			}
 		}

--- a/pkg/sync/status.go
+++ b/pkg/sync/status.go
@@ -175,7 +175,7 @@ func (engine *Engine) UpdatePruneStatus(id, name, namespace string, ch <-chan ev
 }
 
 func (engine *Engine) UpdateErrorStatus(id string, err error) {
-	if err := engine.updateStatus(id, []*console.ComponentAttributes{}, errorAttributes("sync", err)); err != nil {
+	if err := engine.addErrors(id, errorAttributes("sync", err)); err != nil {
 		log.Error(err, "Failed to update service status, ignoring for now")
 	}
 }
@@ -319,6 +319,10 @@ func (engine *Engine) updateStatus(id string, components []*console.ComponentAtt
 	}
 
 	return engine.client.UpdateComponents(id, components, errs)
+}
+
+func (engine *Engine) addErrors(id string, err *console.ServiceErrorAttributes) error {
+	return engine.client.AddServiceErrors(id, []*console.ServiceErrorAttributes{err})
 }
 
 func errorAttributes(source string, err error) *console.ServiceErrorAttributes {


### PR DESCRIPTION
The api can return 403/402 for reasons the agent should just ignore, add some error types to make that feasible.