### PR TITLE
feat: Don't fail on unknown gvks to avoid weird discovery client issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |

--- a/pkg/manifests/template/common.go
+++ b/pkg/manifests/template/common.go
@@ -70,9 +70,10 @@ func setNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 		}
 	}
 	if len(unknownGVKs) > 0 {
-		return &manifestreader.UnknownTypesError{
+		err := &manifestreader.UnknownTypesError{
 			GroupVersionKinds: unknownGVKs,
 		}
+		fmt.Printf("Found unknown types %s, ignoring for now", err)
 	}
 	return nil
 }


### PR DESCRIPTION
The k8s api will eventually fail if they really don't exist so can rely on the statuses there.