### PR TITLE
feat: improve crd status

### DIFF
--- a/pkg/sync/status.go
+++ b/pkg/sync/status.go
@@ -106,7 +106,7 @@ func GetHealthCheckFunc(gvk schema.GroupVersionKind) func(obj *unstructured.Unst
 			return getHPAHealth
 		}
 	}
-	return nil
+	return getOtherHealth
 }
 
 func FormatSummary(namespace, name string, s stats.Stats) error {


### PR DESCRIPTION
The agent should intelligently understand CRD status. This generic method searches for `status` and fetches the conditions. If the condition `Ready` is true then the object is in a `healthy` state.

I have tested it with CD and Cluster API objects