### PR TITLE
fix: Don't sideload jobs in pipeline gate queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/osteele/liquid v1.3.2
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console-client-go v0.0.95
+	github.com/pluralsh/console-client-go v0.1.0
 	github.com/pluralsh/controller-reconcile-helper v0.0.4
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -581,6 +581,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pluralsh/console-client-go v0.0.95 h1:JxZ4FSGDo9Mxu1947i2ipCZquDQ+iWW6FGx3s4/onpA=
 github.com/pluralsh/console-client-go v0.0.95/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
+github.com/pluralsh/console-client-go v0.1.0 h1:Nvu1ch2Q5X0UqndUaCuTC6lL/yzm7ANjKB0xejsNS9I=
+github.com/pluralsh/console-client-go v0.1.0/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
 github.com/pluralsh/controller-reconcile-helper v0.0.4 h1:1o+7qYSyoeqKFjx+WgQTxDz4Q2VMpzprJIIKShxqG0E=
 github.com/pluralsh/controller-reconcile-helper v0.0.4/go.mod h1:AfY0gtteD6veBjmB6jiRx/aR4yevEf6K0M13/pGan/s=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=

--- a/pkg/client/pipelines.go
+++ b/pkg/client/pipelines.go
@@ -216,20 +216,23 @@ func IsJobType(pgFragment *console.PipelineGateFragment) bool {
 }
 
 func HasJobRef(pgFragment *console.PipelineGateFragment) bool {
-	return !(pgFragment.Job == nil || pgFragment.Job.Metadata.Namespace == nil || pgFragment.Job.Metadata.Name == "" || *pgFragment.Job.Metadata.Namespace == "")
+	if pgFragment.Status == nil {
+		return false
+	}
+
+	if pgFragment.Status.JobRef == nil {
+		return false
+	}
+
+	return pgFragment.Status.JobRef.Name != "" && pgFragment.Status.JobRef.Namespace != ""
 }
 
 func GateUpdateAttributes(fragment console.PipelineGateFragment) console.GateUpdateAttributes {
 	var jobRef *console.NamespacedName
-	if fragment.Job != nil && fragment.Job.Metadata.Namespace != nil {
+	if fragment.Status != nil && fragment.Status.JobRef != nil {
 		jobRef = &console.NamespacedName{
-			Name:      fragment.Job.Metadata.Name,
-			Namespace: *fragment.Job.Metadata.Namespace,
-		}
-	} else if fragment.Job != nil {
-		jobRef = &console.NamespacedName{
-			Name:      fragment.Job.Metadata.Name,
-			Namespace: "",
+			Name:      fragment.Status.JobRef.Namespace,
+			Namespace: fragment.Status.JobRef.Name,
 		}
 	} else {
 		jobRef = &console.NamespacedName{}


### PR DESCRIPTION
This is both inefficient, and brittle to cases when the job is pruned on reruns.  Exposed the gate status in the api so we can do it properly (didn't realize it was never queryable).