### PR TITLE
fix: Fix manifest reader inefficiency

### DIFF
--- a/pkg/manifests/template/cache.go
+++ b/pkg/manifests/template/cache.go
@@ -1,0 +1,27 @@
+package template
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	namespacedCache = &gvkCache{cache: map[schema.GroupVersionKind]bool{}}
+)
+
+type gvkCache struct {
+	cache map[schema.GroupVersionKind]bool
+}
+
+func (c *gvkCache) Store(gvk schema.GroupVersionKind, namespaced bool) {
+	c.cache[gvk] = namespaced
+}
+
+func (c *gvkCache) Namespaced(gvk schema.GroupVersionKind) bool {
+	val, ok := c.cache[gvk]
+	return ok && val
+}
+
+func (c *gvkCache) Present(gvk schema.GroupVersionKind) bool {
+	_, ok := c.cache[gvk]
+	return ok
+}

--- a/pkg/manifests/template/raw.go
+++ b/pkg/manifests/template/raw.go
@@ -85,6 +85,7 @@ func (r *raw) Render(svc *console.GetServiceDeploymentForAgent_ServiceDeployment
 		if info.IsDir() {
 			return nil
 		}
+
 		if ext := strings.ToLower(filepath.Ext(info.Name())); !lo.Contains(extensions, ext) {
 			return nil
 		}
@@ -111,7 +112,8 @@ func (r *raw) Render(svc *console.GetServiceDeploymentForAgent_ServiceDeployment
 			Reader:        r,
 			ReaderOptions: readerOptions,
 		}
-		items, err := mReader.Read(res)
+		items, err := mReader.Read([]*unstructured.Unstructured{})
+
 		if err != nil {
 			return fmt.Errorf("failed to parse %s: %w", rpath, err)
 		}

--- a/pkg/manifests/template/reader.go
+++ b/pkg/manifests/template/reader.go
@@ -66,7 +66,6 @@ func (r *StreamManifestReader) Read(objs []*unstructured.Unstructured) ([]*unstr
 	}
 
 	objs = manifestreader.FilterLocalConfig(objs)
-
 	err = setNamespaces(r.Mapper, objs, r.Namespace, r.EnforceNamespace)
 	return objs, err
 }


### PR DESCRIPTION
For some reason this only has popped up when trying to sync opa constraints but there are two major inefficiencies w/ manifest reader right now:

* has to go through RESTMapper to check namespacing (this can sometimes result in a network call, so caching is a meaningful optimization)
* Apparently it doubles the array on each cycle because it calls read on its own result list.  Think we've only used small sets of files for raw resources prior so never became an issue, but it's definitely an issue at large file sets (as you suddenly have a result of like 48k)