### PR TITLE
feat: Invert arg order for many liquid filters

### DIFF
--- a/pkg/manifests/template/raw.go
+++ b/pkg/manifests/template/raw.go
@@ -28,11 +28,8 @@ var (
 		"sha256sum":     "sha26sum",
 		"quote":         "quote",
 		"squote":        "squote",
-		"indent":        "indent",
-		"nindent":       "nindent",
 		"replace":       "replace",
-		"default":       "default",
-		"ternary":       "ternary",
+		"coalesce":      "coalesce",
 	}
 )
 
@@ -41,6 +38,19 @@ func init() {
 	for key, name := range sprigFunctions {
 		liquidEngine.RegisterFilter(name, fncs[key])
 	}
+	liquidEngine.RegisterFilter("indent", indent)
+	liquidEngine.RegisterFilter("nindent", nindent)
+	liquidEngine.RegisterFilter("replace", strings.ReplaceAll)
+
+	liquidEngine.RegisterFilter("default", func(a, b interface{}) interface{} {
+		fun := fncs["default"].(func(interface{}, interface{}) interface{})
+		return fun(b, a)
+	})
+
+	liquidEngine.RegisterFilter("ternary", func(a, b, c interface{}) interface{} {
+		fun := fncs["ternary"].(func(interface{}, interface{}, interface{}) interface{})
+		return fun(c, a, b)
+	})
 }
 
 type raw struct {

--- a/pkg/manifests/template/utils.go
+++ b/pkg/manifests/template/utils.go
@@ -1,6 +1,8 @@
 package template
 
 import (
+	"strings"
+
 	console "github.com/pluralsh/console-client-go"
 )
 
@@ -19,4 +21,13 @@ func contexts(svc *console.GetServiceDeploymentForAgent_ServiceDeployment) map[s
 		res[context.Name] = context.Configuration
 	}
 	return res
+}
+
+func indent(v string, spaces int) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
+}
+
+func nindent(v string, spaces int) string {
+	return "\n" + indent(v, spaces)
 }


### PR DESCRIPTION
Using the sprig library can create an unfortunate devex since pipe arguments work differently in text/template vs liquid.  This should solve for that.