### PR TITLE
fix: Fix image inference for stack runs

### DIFF
--- a/.github/workflows/publish-harness.yaml
+++ b/.github/workflows/publish-harness.yaml
@@ -116,9 +116,9 @@ jobs:
             ghcr.io/pluralsh/stackrun-harness
             docker.io/pluralsh/stackrun-harness
           tags: |
-            type=semver,pattern={{version}},suffix=-terraform${{ env.TERRAFORM_VERSION }},priority=1000
-            type=sha,suffix=-terraform${{ env.TERRAFORM_VERSION }},priority=800
-            type=ref,event=pr,suffix=-terraform${{ env.TERRAFORM_VERSION }},priority=600
+            type=semver,pattern={{version}},suffix=-terraform-${{ env.TERRAFORM_VERSION }},priority=1000
+            type=sha,suffix=-terraform-${{ env.TERRAFORM_VERSION }},priority=800
+            type=ref,event=pr,suffix=-terraform-${{ env.TERRAFORM_VERSION }},priority=600
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/charts/deployment-operator/templates/deployment.yaml
+++ b/charts/deployment-operator/templates/deployment.yaml
@@ -33,7 +33,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{ $tag := .Values.image.tag | default .Chart.AppVersion }}
+          image: "{{ .Values.image.repository }}:{{ $tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
           - secretRef:
@@ -45,6 +46,9 @@ spec:
           - -processing-timeout={{ .Values.args.processingTimeout }}
           - -enable-helm-dependency-update={{ .Values.args.enableHelmDependencyUpdate }}
           - -disable-helm-dry-run-server={{ .Values.args.disableHelmTemplateDryRunServer }}
+          env:
+          - name: IMAGE_TAG
+            value: {{ $tag | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/pkg/controller/stacks/job.go
+++ b/pkg/controller/stacks/job.go
@@ -3,6 +3,7 @@ package stacks
 import (
 	"context"
 	"fmt"
+	"os"
 
 	console "github.com/pluralsh/console-client-go"
 	consoleclient "github.com/pluralsh/deployment-operator/pkg/client"
@@ -34,7 +35,15 @@ var (
 		console.StackTypeTerraform: "latest",
 		console.StackTypeAnsible:   "latest",
 	}
+
+	defaultImageTag = "latest"
 )
+
+func init() {
+	if os.Getenv("IMAGE_TAG") != "" {
+		defaultImageTag = os.Getenv("IMAGE_TAG")
+	}
+}
 
 func (r *StackReconciler) reconcileRunJob(ctx context.Context, run *console.StackRunFragment) (*batchv1.Job, error) {
 	logger := log.FromContext(ctx)
@@ -190,7 +199,7 @@ func (r *StackReconciler) getDefaultContainerImage(run *console.StackRunFragment
 		version = run.Configuration.Version
 	}
 
-	return fmt.Sprintf("%s:%s", image, version)
+	return fmt.Sprintf("%s:%s-%s-%s", defaultImageTag, string(run.Type), image, version)
 }
 
 func (r *StackReconciler) getDefaultContainerArgs(runID string) []string {


### PR DESCRIPTION
The reconciler wasn't correctly specifying the harness image given surrounding information.  This should be a slightly better default.