### PR TITLE
fix: Fix filepath setup

### DIFF
--- a/dockerfiles/harness/base.Dockerfile
+++ b/dockerfiles/harness/base.Dockerfile
@@ -49,4 +49,6 @@ COPY --chown=nonroot --from=environment /bin/sh /bin/sh
 COPY --chown=nonroot --from=environment /bin/sleep /bin/sleep
 COPY --from=builder /plural/harness /harness
 
-ENTRYPOINT ["/harness", "--working-dir=plural"]
+WORKDIR /plural
+
+ENTRYPOINT ["/harness", "--working-dir=/plural"]

--- a/internal/helpers/env.go
+++ b/internal/helpers/env.go
@@ -71,7 +71,7 @@ func EnsureFileOrDie(file string) string {
 	return f.Name()
 }
 
-func IsExists(file string) bool {
+func Exists(file string) bool {
 	_, err := os.Stat(file)
 	return err == nil
 }

--- a/internal/helpers/file.go
+++ b/internal/helpers/file.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"os"
+	"path/filepath"
 )
 
 var (
@@ -19,5 +20,9 @@ func File() FileClient {
 type fileClient struct{}
 
 func (in *fileClient) Create(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
 	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/pkg/harness/controller/controller.go
+++ b/pkg/harness/controller/controller.go
@@ -185,7 +185,7 @@ func (in *stackRunController) prepare() error {
 	env := environment.New(
 		environment.WithStackRun(in.stackRun),
 		environment.WithWorkingDir(in.dir),
-		environment.WithFilesDir(in.execWorkDir()),
+		environment.WithFilesDir(in.dir),
 		environment.WithFetchClient(in.fetchClient),
 	)
 

--- a/pkg/harness/environment/environment.go
+++ b/pkg/harness/environment/environment.go
@@ -1,8 +1,6 @@
 package environment
 
 import (
-	"path"
-
 	"k8s.io/klog/v2"
 
 	"github.com/pluralsh/deployment-operator/internal/helpers"
@@ -38,7 +36,7 @@ func (in *environment) prepareFiles() error {
 	}
 
 	for _, fragment := range in.stackRun.Files {
-		destination := path.Join(in.filesDir, fragment.Path)
+		destination := fragment.Path
 		if err := helpers.File().Create(destination, fragment.Content); err != nil {
 			klog.ErrorS(err, "failed preparing files", "path", destination)
 			return err

--- a/pkg/harness/tool/terraform/modifier.go
+++ b/pkg/harness/tool/terraform/modifier.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/pluralsh/polly/algorithms"
+	"github.com/samber/lo"
 
 	"github.com/pluralsh/deployment-operator/internal/helpers"
 )
@@ -20,9 +20,7 @@ func NewInitModifier() *InitModifier {
 
 // Args implements exec.ArgsModifier type.
 func (in *PlanModifier) Args(args []string) []string {
-	if algorithms.Index(args, func(a string) bool {
-		return a == "plan"
-	}) < 0 {
+	if !lo.Contains(args, "plan") {
 		return args
 	}
 
@@ -34,11 +32,11 @@ func NewPlanModifier(planFileName string) *PlanModifier {
 }
 
 func (in *ApplyModifier) Args(args []string) []string {
-	if !helpers.IsExists(path.Join(in.dir, in.planFileName)) ||
-		// This is to avoid doubling plan file arg if API already adds it
-		algorithms.Index(args, func(a string) bool {
-			return a == in.planFileName
-		}) >= 0 {
+	if !lo.Contains(args, "apply") {
+		return args
+	}
+
+	if !helpers.Exists(path.Join(in.dir, in.planFileName)) || lo.Contains(args, in.planFileName) {
 		return args
 	}
 


### PR DESCRIPTION
With the new mountPath spec, you can assume users specify a full/correct path in harness