### PR TITLE
feat(harness): add proper timeout handling for stack run step

### DIFF
--- a/cmd/harness/args/args.go
+++ b/cmd/harness/args/args.go
@@ -39,7 +39,7 @@ var (
 	argConsoleToken       = pflag.String("console-token", helpers.GetPluralEnv(EnvConsoleToken, ""), "Deploy token to the Console API")
 	argStackRunID         = pflag.String("stack-run-id", helpers.GetPluralEnv(EnvStackRunID, ""), "ID of the Stack Run to execute")
 	argWorkingDir         = pflag.String("working-dir", helpers.GetPluralEnv(EnvWorkingDir, defaultWorkingDir), "Working directory used to prepare the environment")
-	argTimeout            = pflag.String("timeout", helpers.GetPluralEnv(EnvTimeout, defaultTimeout), "Timeout after which run will be cancelled")
+	argTimeout            = pflag.String("timeout", helpers.GetPluralEnv(EnvTimeout, defaultTimeout), "Timeout is the maximum time each stack run step can run before it will be cancelled")
 	argLogFlushFrequency  = pflag.String("log-flush-frequency", helpers.GetPluralEnv(EnvLogFlushFrequency, defaultLogFlushFrequency), "Frequency at which logs should be flushed if buffer is not full")
 	argLogFlushBufferSize = pflag.Int("log-flush-buffer-size", helpers.ParseIntOrDie(helpers.GetPluralEnv(EnvLogFlushBufferSize, defaultLogFlushBufferSize)), "Buffer size to use for log flushing (in kilobytes)")
 )

--- a/cmd/harness/main.go
+++ b/cmd/harness/main.go
@@ -46,7 +46,6 @@ func main() {
 	}
 
 	if err = ctrl.Start(ctx); err != nil {
-		_ = ctrl.Finish(err)
 		handleFatalError(err)
 	}
 }

--- a/pkg/harness/controller/controller.go
+++ b/pkg/harness/controller/controller.go
@@ -127,13 +127,16 @@ func (in *stackRunController) toExecutable(ctx context.Context, step *gqlclient.
 
 	return exec.NewExecutable(
 		step.Cmd,
-		exec.WithDir(in.execWorkDir()),
-		exec.WithEnv(in.stackRun.Env()),
-		exec.WithArgs(args),
-		exec.WithID(step.ID),
-		exec.WithLogSink(consoleWriter),
-		exec.WithHook(v1.LifecyclePreStart, in.preExecHook(step.Stage, step.ID)),
-		exec.WithHook(v1.LifecyclePostStart, in.postExecHook(step.Stage)),
+		append(
+			in.execOptions,
+			exec.WithDir(in.execWorkDir()),
+			exec.WithEnv(in.stackRun.Env()),
+			exec.WithArgs(args),
+			exec.WithID(step.ID),
+			exec.WithLogSink(consoleWriter),
+			exec.WithHook(v1.LifecyclePreStart, in.preExecHook(step.Stage, step.ID)),
+			exec.WithHook(v1.LifecyclePostStart, in.postExecHook(step.Stage)),
+		)...,
 	)
 }
 

--- a/pkg/harness/controller/controller.go
+++ b/pkg/harness/controller/controller.go
@@ -159,7 +159,7 @@ func (in *stackRunController) completeStackRun(status gqlclient.StackStatus, sta
 	serviceErrorAttributes := make([]*gqlclient.ServiceErrorAttributes, 0)
 	if stackRunErr != nil {
 		serviceErrorAttributes = append(serviceErrorAttributes, &gqlclient.ServiceErrorAttributes{
-			Source: "harness",
+			Source:  "harness",
 			Message: stackRunErr.Error(),
 		})
 	}

--- a/pkg/harness/controller/controller.go
+++ b/pkg/harness/controller/controller.go
@@ -159,6 +159,7 @@ func (in *stackRunController) completeStackRun(status gqlclient.StackStatus, sta
 	serviceErrorAttributes := make([]*gqlclient.ServiceErrorAttributes, 0)
 	if stackRunErr != nil {
 		serviceErrorAttributes = append(serviceErrorAttributes, &gqlclient.ServiceErrorAttributes{
+			Source: "harness",
 			Message: stackRunErr.Error(),
 		})
 	}

--- a/pkg/harness/controller/controller_hooks.go
+++ b/pkg/harness/controller/controller_hooks.go
@@ -39,7 +39,7 @@ func (in *stackRunController) preStart() {
 }
 
 // postStart function is executed after all stack run steps.
-func (in *stackRunController) postStart(err error) error {
+func (in *stackRunController) postStart(err error) {
 	var status gqlclient.StackStatus
 
 	switch {
@@ -56,7 +56,6 @@ func (in *stackRunController) postStart(err error) error {
 	}
 
 	klog.V(log.LogLevelInfo).InfoS("stack run completed")
-	return err
 }
 
 // postStepRun is a callback function started by the executor after executable finishes.
@@ -105,7 +104,7 @@ func (in *stackRunController) preExecHook(stage gqlclient.StepStage, id string) 
 }
 
 func (in *stackRunController) requiresApproval() bool {
-	return in.stackRun.Approval && !runApproved
+	return in.stackRun.Approval && !runApproved && in.stackRun.ApprovedAt == nil
 }
 
 func (in *stackRunController) waitForApproval() {

--- a/pkg/harness/controller/controller_hooks.go
+++ b/pkg/harness/controller/controller_hooks.go
@@ -33,7 +33,6 @@ func (in *stackRunController) preStart() {
 	if in.stackRun.ManageState {
 		err := in.tool.ConfigureStateBackend("harness", in.consoleToken, in.stackRun.StateUrls)
 		if err != nil {
-			// TODO: Should this be a fatal error?
 			klog.Fatalf("could not configure state backend: %v", err)
 		}
 	}
@@ -79,7 +78,7 @@ func (in *stackRunController) postStepRun(id string, err error) {
 }
 
 // postExecHook is a callback function started by the exec.Executable after it finishes.
-// It differs from the
+// Unlike postStepRun it does provide any additional information.
 func (in *stackRunController) postExecHook(stage gqlclient.StepStage) v1.HookFunction {
 	return func() error {
 		if stage != gqlclient.StepStagePlan {
@@ -90,6 +89,7 @@ func (in *stackRunController) postExecHook(stage gqlclient.StepStage) v1.HookFun
 	}
 }
 
+// postExecHook is a callback function started by the exec.Executable before it runs the executable.
 func (in *stackRunController) preExecHook(stage gqlclient.StepStage, id string) v1.HookFunction {
 	return func() error {
 		if stage == gqlclient.StepStageApply && in.requiresApproval() {

--- a/pkg/harness/controller/controller_options.go
+++ b/pkg/harness/controller/controller_options.go
@@ -1,10 +1,9 @@
 package controller
 
 import (
-	"time"
-
 	"github.com/pluralsh/deployment-operator/internal/helpers"
 	console "github.com/pluralsh/deployment-operator/pkg/client"
+	"github.com/pluralsh/deployment-operator/pkg/harness/exec"
 	"github.com/pluralsh/deployment-operator/pkg/harness/sink"
 )
 
@@ -38,9 +37,9 @@ func WithSinkOptions(options ...sink.Option) Option {
 	}
 }
 
-func WithStackRunStepTimeout(timeout time.Duration) Option {
+func WithExecOptions(options ...exec.Option) Option {
 	return func(s *stackRunController) {
-		s.stackRunStepTimeout = timeout
+		s.execOptions = options
 	}
 }
 

--- a/pkg/harness/controller/controller_types.go
+++ b/pkg/harness/controller/controller_types.go
@@ -14,7 +14,6 @@ import (
 
 type Controller interface {
 	Start(ctx context.Context) error
-	Finish(stackRunErr error) error
 }
 
 type stackRunController struct {

--- a/pkg/harness/controller/controller_types.go
+++ b/pkg/harness/controller/controller_types.go
@@ -3,10 +3,10 @@ package controller
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/pluralsh/deployment-operator/internal/helpers"
 	console "github.com/pluralsh/deployment-operator/pkg/client"
+	"github.com/pluralsh/deployment-operator/pkg/harness/exec"
 	"github.com/pluralsh/deployment-operator/pkg/harness/sink"
 	stackrunv1 "github.com/pluralsh/deployment-operator/pkg/harness/stackrun/v1"
 	toolv1 "github.com/pluralsh/deployment-operator/pkg/harness/tool/v1"
@@ -32,9 +32,6 @@ type stackRunController struct {
 	// stackRunID
 	stackRunID string
 
-	// stackRunStepTimeout
-	stackRunStepTimeout time.Duration
-
 	// stackRun
 	stackRun *stackrunv1.StackRun
 
@@ -49,6 +46,9 @@ type stackRunController struct {
 
 	// dir
 	dir string
+
+	// execOptions
+	execOptions []exec.Option
 
 	// sinkOptions allows providing custom options to
 	// sink.ConsoleWriter. By default, every command output

--- a/pkg/harness/exec/exec_options.go
+++ b/pkg/harness/exec/exec_options.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"io"
+	"time"
 
 	v1 "github.com/pluralsh/deployment-operator/pkg/harness/stackrun/v1"
 )
@@ -39,5 +40,11 @@ func WithID(id string) Option {
 func WithHook(lifecycle v1.Lifecycle, fn v1.HookFunction) Option {
 	return func(e *executable) {
 		e.hookFunctions[lifecycle] = fn
+	}
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(e *executable) {
+		e.timeout = timeout
 	}
 }

--- a/pkg/harness/exec/exec_types.go
+++ b/pkg/harness/exec/exec_types.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"context"
 	"io"
+	"time"
 
 	v1 "github.com/pluralsh/deployment-operator/pkg/harness/stackrun/v1"
 )
@@ -34,6 +35,9 @@ type executable struct {
 
 	// args
 	args []string
+
+	// timeout
+	timeout time.Duration
 
 	// logSink is a custom writer that can be used to forward
 	// executable output. It does not stop output from being forwarded

--- a/pkg/harness/tool/ansible/ansible.go
+++ b/pkg/harness/tool/ansible/ansible.go
@@ -27,7 +27,7 @@ func (in *Ansible) Modifier(stage console.StepStage) v1.Modifier {
 }
 
 func (in *Ansible) ConfigureStateBackend(actor, deployToken string, urls *console.StackRunBaseFragment_StateUrls) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 

--- a/pkg/harness/tool/terraform/terraform_types.go
+++ b/pkg/harness/tool/terraform/terraform_types.go
@@ -9,4 +9,3 @@ type Terraform struct {
 	// Default: terraform.tfplan
 	planFileName string
 }
-


### PR DESCRIPTION
- Use defer to ensure `postStart` hook is always executed in the controller. Previously, `postStart` was often being called twice, both by `Start` and `Finish` methods.
- Optimize approval check