### PR TITLE
enhancement: use opentofu binary in harness terraform image

### DIFF
--- a/.github/workflows/publish-harness.yaml
+++ b/.github/workflows/publish-harness.yaml
@@ -96,30 +96,14 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [publish-harness-base]
     env:
-      TERRAFORM_VERSION: 1.8.2
+      TOFU_VERESION: 1.7.2
     strategy:
       matrix:
         versions:
-        - full: 1.8.2
-          tag: 1.8.2
-        - full: 1.8.2
-          tag: "1.8"
-        - full: 1.7.5
-          tag: '1.7'
-        - full: 1.6.6
-          tag: '1.6'
-        - full: 1.5.7
-          tag: '1.5'
-        - full: 1.4.7
-          tag: '1.4'
-        - full: 1.3.10
-          tag: '1.3'
-        - full: 1.2.9
-          tag: '1.2'
-        - full: 1.1.9
-          tag: '1.1'
-        - full: 1.0.11
-          tag: '1.0'
+        - full: 1.7.2
+          tag:  '1.7'
+        - full: 1.6.2
+          tag:  '1.6'
     permissions:
       contents: write
       discussions: write
@@ -169,7 +153,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            TERRAFORM_IMAGE_TAG=${{ matrix.versions.full }}
+            TOFU_IMAGE_TAG=${{ matrix.versions.full }}
             HARNESS_BASE_IMAGE_REPO=ghcr.io/pluralsh/stackrun-harness-base
             HARNESS_BASE_IMAGE_TAG=${{ needs.publish-harness-base.outputs.version }}
             

--- a/dockerfiles/harness/terraform.Dockerfile
+++ b/dockerfiles/harness/terraform.Dockerfile
@@ -1,11 +1,11 @@
-ARG TERRAFORM_IMAGE_TAG=1.8.2
-ARG TERRAFORM_IMAGE=hashicorp/terraform:$TERRAFORM_IMAGE_TAG
+ARG TOFU_IMAGE_TAG=1.7.1
+ARG TOFU_IMAGE=ghcr.io/opentofu/opentofu:$TOFU_IMAGE_TAG
 
 ARG HARNESS_BASE_IMAGE_TAG=latest
 ARG HARNESS_BASE_IMAGE_REPO=harness-base
 ARG HARNESS_BASE_IMAGE=$HARNESS_BASE_IMAGE_REPO:$HARNESS_BASE_IMAGE_TAG
 
-FROM $TERRAFORM_IMAGE as terraform
+FROM $TOFU_IMAGE as tofu
 FROM $HARNESS_BASE_IMAGE as final
 
-COPY --from=terraform /bin/terraform /bin/terraform
+COPY --from=tofu /usr/local/bin/tofu /bin/terraform


### PR DESCRIPTION
To avoid violating Terraform's BSL license, we are using the [OpenTofu](https://github.com/opentofu/opentofu) binary