### PR TITLE
fix: do not allow discovery api call for helm templating to stop the agent

### DIFF
--- a/cmd/agent/options.go
+++ b/cmd/agent/options.go
@@ -38,7 +38,7 @@ func newOptions() *options {
 	flag.StringVar(&o.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&o.probeAddr, "health-probe-bind-address", ":9001", "The address the probe endpoint binds to.")
 	flag.BoolVar(&o.enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&o.maxConcurrentReconciles, "max-concurrent-reconciles", 10, "Maximum number of concurrent reconciles which can be run.")
+	flag.IntVar(&o.maxConcurrentReconciles, "max-concurrent-reconciles", 20, "Maximum number of concurrent reconciles which can be run.")
 	flag.IntVar(&o.resyncSeconds, "resync-seconds", 300, "Resync duration in seconds.")
 	flag.StringVar(&o.refreshInterval, "refresh-interval", "2m", "Refresh interval duration.")
 	flag.StringVar(&o.processingTimeout, "processing-timeout", "1m", "Maximum amount of time to spend trying to process queue item.")

--- a/internal/helpers/poll.go
+++ b/internal/helpers/poll.go
@@ -1,0 +1,24 @@
+package helpers
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// BackgroundPollUntilContextCancel spawns a new goroutine that runs the condition function on interval.
+// If syncFirstRun is set to true, it will execute the condition function synchronously first and then start
+// polling. Since error is returned synchronously, the only way to check for it is to use syncFirstRun.
+// Background poller does not sync errors. It can be stopped externally by cancelling the provided context.
+func BackgroundPollUntilContextCancel(ctx context.Context, interval time.Duration, immediate, syncFirstRun bool, condition wait.ConditionWithContextFunc) (err error) {
+	if syncFirstRun {
+		_, err = condition(ctx)
+	}
+
+	go func() {
+		_ = wait.PollUntilContextCancel(ctx, interval, immediate, condition)
+	}()
+
+	return err
+}

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -7,17 +7,6 @@ import (
 	"time"
 
 	console "github.com/pluralsh/console-client-go"
-	clienterrors "github.com/pluralsh/deployment-operator/internal/errors"
-	"github.com/pluralsh/deployment-operator/internal/utils"
-	"github.com/pluralsh/deployment-operator/pkg/applier"
-	"github.com/pluralsh/deployment-operator/pkg/client"
-	"github.com/pluralsh/deployment-operator/pkg/controller"
-	plrlerrors "github.com/pluralsh/deployment-operator/pkg/errors"
-	"github.com/pluralsh/deployment-operator/pkg/manifests"
-	manis "github.com/pluralsh/deployment-operator/pkg/manifests"
-	"github.com/pluralsh/deployment-operator/pkg/manifests/template"
-	"github.com/pluralsh/deployment-operator/pkg/ping"
-	"github.com/pluralsh/deployment-operator/pkg/websocket"
 	"github.com/pluralsh/polly/algorithms"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +23,18 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	clienterrors "github.com/pluralsh/deployment-operator/internal/errors"
+	"github.com/pluralsh/deployment-operator/internal/utils"
+	"github.com/pluralsh/deployment-operator/pkg/applier"
+	"github.com/pluralsh/deployment-operator/pkg/client"
+	"github.com/pluralsh/deployment-operator/pkg/controller"
+	plrlerrors "github.com/pluralsh/deployment-operator/pkg/errors"
+	"github.com/pluralsh/deployment-operator/pkg/manifests"
+	manis "github.com/pluralsh/deployment-operator/pkg/manifests"
+	"github.com/pluralsh/deployment-operator/pkg/manifests/template"
+	"github.com/pluralsh/deployment-operator/pkg/ping"
+	"github.com/pluralsh/deployment-operator/pkg/websocket"
 )
 
 func init() {
@@ -106,13 +107,9 @@ func NewServiceReconciler(ctx context.Context, consoleClient client.Client, conf
 	if err != nil {
 		return nil, err
 	}
-	if err := CapabilitiesAPIVersions(discoveryClient); err != nil {
-		return nil, err
-	}
 
 	go func() {
-		//nolint:all
-		_ = wait.PollImmediateInfinite(time.Minute*5, func() (done bool, err error) {
+		_ = wait.PollUntilContextCancel(ctx, time.Minute*5, true, func(_ context.Context) (done bool, err error) {
 			if err := CapabilitiesAPIVersions(discoveryClient); err != nil {
 				logger.Error(err, "can't fetch API versions")
 			}

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -108,7 +108,7 @@ func NewServiceReconciler(ctx context.Context, consoleClient client.Client, conf
 		return nil, err
 	}
 
-	_ = helpers.BackgroundPollUntilContextCancel(ctx, 5 * time.Minute, true, true, func(_ context.Context) (done bool, err error) {
+	_ = helpers.BackgroundPollUntilContextCancel(ctx, 5*time.Minute, true, true, func(_ context.Context) (done bool, err error) {
 		if err := CapabilitiesAPIVersions(discoveryClient); err != nil {
 			logger.Error(err, "can't fetch API versions")
 		}


### PR DESCRIPTION
- Use structured logging for top-level agent error logs
- Use non-deprecated polling function for `APIVersions` map updates
- Bump default number of concurrent reconciles to 20