### PR TITLE
fix: Work on fix for status bug

### DIFF
--- a/internal/kstatus/watcher/common.go
+++ b/internal/kstatus/watcher/common.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	kwatcher "sigs.k8s.io/cli-utils/pkg/kstatus/watcher"
 	"sigs.k8s.io/cli-utils/pkg/object"
+
+	"github.com/samber/lo"
 )
 
 func handleFatalError(err error) <-chan event.Event {
@@ -23,6 +25,10 @@ func handleFatalError(err error) <-chan event.Event {
 }
 
 func autoSelectRESTScopeStrategy(ids object.ObjMetadataSet) kwatcher.RESTScopeStrategy {
+	if lo.EveryBy(ids, func(id object.ObjMetadata) bool { return id.Namespace == "" }) {
+		return kwatcher.RESTScopeRoot
+	}
+
 	if len(uniqueNamespaces(ids)) > 1 {
 		return kwatcher.RESTScopeRoot
 	}

--- a/internal/kstatus/watcher/object_status_reporter.go
+++ b/internal/kstatus/watcher/object_status_reporter.go
@@ -331,7 +331,7 @@ func (in *ObjectStatusReporter) newWatcher(ctx context.Context, gkn GroupKindNam
 		return nil, err
 	}
 
-	gvr := GvrFromGvk(mapping.GroupVersionKind)
+	gvr := mapping.Resource
 
 	var labelSelectorString string
 	if in.LabelSelector != nil {
@@ -759,7 +759,7 @@ func (in *ObjectStatusReporter) newStatusCheckTaskFunc(
 }
 
 func (in *ObjectStatusReporter) handleFatalError(eventCh chan<- event.Event, err error) {
-	klog.V(5).Infof("Reporter error: %v", err)
+	klog.Warningf("Reporter error: %v", err)
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}

--- a/pkg/cache/resource_cache.go
+++ b/pkg/cache/resource_cache.go
@@ -194,7 +194,7 @@ func (in *ResourceCache) GetCacheStatus(key object.ObjMetadata) (*console.Compon
 		return nil, err
 	}
 
-	gvr := watcher.GvrFromGvk(mapping.GroupVersionKind)
+	gvr := mapping.Resource
 	obj, err := in.dynamicClient.Resource(gvr).Namespace(key.Namespace).Get(context.Background(), key.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It looks like OPA Gatekeeper uses irregular GroupVersionResource values (and this is a fringe possibility for other resources as well), that the inflect-based logic we were using fails for.  Just getting this from the RestMapper mimics cli-utils existing functionality and is more robust

Fixes PROD-2425