### PR TITLE
feat(harness): add stackrun variables support to terraform

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/open-policy-agent/gatekeeper/v3 v3.15.1
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console/go/client v1.8.0
+	github.com/pluralsh/console/go/client v1.12.0
 	github.com/pluralsh/controller-reconcile-helper v0.0.4
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rK
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pluralsh/console/go/client v1.8.0 h1:iFMb8mNExuko0ffKReUzqaplgfcL3CI/lAgaWiVyCUE=
-github.com/pluralsh/console/go/client v1.8.0/go.mod h1:lpoWASYsM9keNePS3dpFiEisUHEfObIVlSL3tzpKn8k=
+github.com/pluralsh/console/go/client v1.12.0 h1:1djVBV9GMEe1I6yKv0bWu2Qx8dnsVgGzhntGSY+KLCw=
+github.com/pluralsh/console/go/client v1.12.0/go.mod h1:lpoWASYsM9keNePS3dpFiEisUHEfObIVlSL3tzpKn8k=
 github.com/pluralsh/controller-reconcile-helper v0.0.4 h1:1o+7qYSyoeqKFjx+WgQTxDz4Q2VMpzprJIIKShxqG0E=
 github.com/pluralsh/controller-reconcile-helper v0.0.4/go.mod h1:AfY0gtteD6veBjmB6jiRx/aR4yevEf6K0M13/pGan/s=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=

--- a/internal/helpers/env.go
+++ b/internal/helpers/env.go
@@ -2,8 +2,10 @@ package helpers
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -61,10 +63,16 @@ func EnsureDirOrDie(dir string) {
 	klog.V(log.LogLevelDebug).Infof("created directory: %s", dir)
 }
 
-func EnsureFileOrDie(file string) string {
+func EnsureFileOrDie(file string, content *string) string {
 	f, err := os.Create(file)
 	if err != nil && !os.IsExist(err) {
 		panic(fmt.Errorf("could not create file: %w", err))
+	}
+
+	if content != nil {
+		if _, err = io.Copy(f, strings.NewReader(*content)); err != nil {
+			panic(fmt.Errorf("could not copy content: %w", err))
+		}
 	}
 
 	klog.V(log.LogLevelDebug).Infof("created file: %s", file)

--- a/pkg/harness/controller/controller.go
+++ b/pkg/harness/controller/controller.go
@@ -200,7 +200,12 @@ func (in *stackRunController) prepare() error {
 		return err
 	}
 
-	in.tool = tool.New(in.stackRun.Type, in.dir, in.execWorkDir())
+	variables, err := in.stackRun.Vars()
+	if err != nil {
+		return err
+	}
+
+	in.tool = tool.New(in.stackRun.Type, in.dir, in.execWorkDir(), variables)
 
 	return nil
 }

--- a/pkg/harness/stackrun/v1/types.go
+++ b/pkg/harness/stackrun/v1/types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"fmt"
 
 	gqlclient "github.com/pluralsh/console/go/client"
@@ -21,6 +22,7 @@ type StackRun struct {
 	ManageState bool
 	Creds       *gqlclient.StackRunBaseFragment_PluralCreds
 	StateUrls   *gqlclient.StackRunBaseFragment_StateUrls
+	Variables   map[string]interface{}
 }
 
 func (in *StackRun) FromStackRunBaseFragment(fragment *gqlclient.StackRunBaseFragment) *StackRun {
@@ -38,6 +40,7 @@ func (in *StackRun) FromStackRunBaseFragment(fragment *gqlclient.StackRunBaseFra
 		ManageState: fragment.ManageState != nil && *fragment.ManageState,
 		Creds:       fragment.PluralCreds,
 		StateUrls:   fragment.StateUrls,
+		Variables:   fragment.Variables,
 	}
 }
 
@@ -56,6 +59,16 @@ func (in *StackRun) Env() []string {
 	}
 
 	return env
+}
+
+// Vars parses the StackRun.Variables map as a valid JSON.
+func (in *StackRun) Vars() (*string, error) {
+	if in.Variables == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(in.Variables)
+	return lo.ToPtr(string(data)), err
 }
 
 type Lifecycle string

--- a/pkg/harness/tool/ansible/ansible.go
+++ b/pkg/harness/tool/ansible/ansible.go
@@ -28,24 +28,31 @@ func (in *Ansible) Plan() (*console.StackStateAttributes, error) {
 
 // Modifier implements [v1.Tool] interface.
 func (in *Ansible) Modifier(stage console.StepStage) v1.Modifier {
-	globalEnvModifier := NewGlobalEnvModifier(in.workDir)
+	modifiers := []v1.Modifier{NewGlobalEnvModifier(in.workDir)}
 
-	if stage == console.StepStagePlan {
-		return v1.NewMultiModifier(NewPassthroughModifier(in.planFilePath), globalEnvModifier)
+	if in.variables != nil {
+		modifiers = append(modifiers, NewVariableInjectorModifier(in.variablesFileName))
 	}
 
-	return globalEnvModifier
+	if stage == console.StepStagePlan {
+		modifiers = append(modifiers, NewPassthroughModifier(in.planFilePath))
+	}
+
+	return v1.NewMultiModifier(modifiers...)
 }
 
 func (in *Ansible) init() *Ansible {
 	in.planFileName = "ansible.plan"
 	in.planFilePath = path.Join(in.execDir, in.planFileName)
-	helpers.EnsureFileOrDie(in.planFilePath)
+	helpers.EnsureFileOrDie(in.planFilePath, nil)
+
+	in.variablesFileName = "plural.variables.json"
+	helpers.EnsureFileOrDie(path.Join(in.execDir, in.variablesFileName), in.variables)
 
 	return in
 }
 
 // New creates an Ansible structure that implements v1.Tool interface.
-func New(workDir, execDir string) v1.Tool {
-	return (&Ansible{workDir: workDir, execDir: execDir}).init()
+func New(workDir, execDir string, variables *string) v1.Tool {
+	return (&Ansible{workDir: workDir, execDir: execDir, variables: variables}).init()
 }

--- a/pkg/harness/tool/ansible/ansible.go
+++ b/pkg/harness/tool/ansible/ansible.go
@@ -46,13 +46,10 @@ func (in *Ansible) init() *Ansible {
 	in.planFilePath = path.Join(in.execDir, in.planFileName)
 	helpers.EnsureFileOrDie(in.planFilePath, nil)
 
-	in.variablesFileName = "plural.variables.json"
-	helpers.EnsureFileOrDie(path.Join(in.execDir, in.variablesFileName), in.variables)
-
 	return in
 }
 
 // New creates an Ansible structure that implements v1.Tool interface.
-func New(workDir, execDir string, variables *string) v1.Tool {
-	return (&Ansible{workDir: workDir, execDir: execDir, variables: variables}).init()
+func New(workDir, execDir string) v1.Tool {
+	return (&Ansible{workDir: workDir, execDir: execDir}).init()
 }

--- a/pkg/harness/tool/ansible/ansible_types.go
+++ b/pkg/harness/tool/ansible/ansible_types.go
@@ -19,4 +19,12 @@ type Ansible struct {
 
 	// planFilePath
 	planFilePath string
+
+	// variablesFileName is an ansible variables file name.
+	// Default: plural.variables.json
+	variablesFileName string
+
+	// variables is a JSON encoded string representing
+	// ansible variable file.
+	variables *string
 }

--- a/pkg/harness/tool/ansible/modifier.go
+++ b/pkg/harness/tool/ansible/modifier.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"k8s.io/klog/v2"
 
@@ -24,10 +25,13 @@ func NewPassthroughModifier(planFile string) v1.Modifier {
 }
 
 func (in *GlobalEnvModifier) Env(env []string) []string {
-	//ansibleHome := path.Join(in.workDir, ansibleDir)
-	//ansibleTmp := path.Join(ansibleHome, ansibleTmpDir)
+	ansibleHome := path.Join(in.workDir, ansibleDir)
+	ansibleTmp := path.Join(ansibleHome, ansibleTmpDir)
 
-	return env
+	return append(env,
+		fmt.Sprintf("ANSIBLE_HOME=%s", ansibleHome),
+		fmt.Sprintf("ANSIBLE_REMOTE_TMP=%s", ansibleTmp),
+	)
 }
 
 func NewGlobalEnvModifier(workDir string) v1.Modifier {

--- a/pkg/harness/tool/ansible/modifier.go
+++ b/pkg/harness/tool/ansible/modifier.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"k8s.io/klog/v2"
 
@@ -25,15 +24,20 @@ func NewPassthroughModifier(planFile string) v1.Modifier {
 }
 
 func (in *GlobalEnvModifier) Env(env []string) []string {
-	ansibleHome := path.Join(in.workDir, ansibleDir)
-	ansibleTmp := path.Join(ansibleHome, ansibleTmpDir)
+	//ansibleHome := path.Join(in.workDir, ansibleDir)
+	//ansibleTmp := path.Join(ansibleHome, ansibleTmpDir)
 
-	return append(env,
-		fmt.Sprintf("ANSIBLE_HOME=%s", ansibleHome),
-		fmt.Sprintf("ANSIBLE_REMOTE_TMP=%s", ansibleTmp),
-	)
+	return env
 }
 
 func NewGlobalEnvModifier(workDir string) v1.Modifier {
 	return &GlobalEnvModifier{workDir: workDir}
+}
+
+func (in *VariableInjectorModifier) Args(args []string) []string {
+	return append(args, fmt.Sprintf("--extra-vars @%s", in.variablesFile))
+}
+
+func NewVariableInjectorModifier(variablesFile string) v1.Modifier {
+	return &VariableInjectorModifier{variablesFile: variablesFile}
 }

--- a/pkg/harness/tool/ansible/modifier_types.go
+++ b/pkg/harness/tool/ansible/modifier_types.go
@@ -20,6 +20,13 @@ type GlobalEnvModifier struct {
 	workDir string
 }
 
+type VariableInjectorModifier struct {
+	v1.DefaultModifier
+
+	// variablesFile
+	variablesFile string
+}
+
 const (
 	ansibleDir    = ".ansible"
 	ansibleTmpDir = "tmp"

--- a/pkg/harness/tool/terraform/terraform.go
+++ b/pkg/harness/tool/terraform/terraform.go
@@ -142,14 +142,17 @@ func (in *Terraform) plan() (string, error) {
 	return string(output), nil
 }
 
-func (in *Terraform) init() *Terraform {
+func (in *Terraform) init() v1.Tool {
 	in.planFileName = "terraform.tfplan"
-	helpers.EnsureFileOrDie(path.Join(in.dir, in.planFileName))
+	helpers.EnsureFileOrDie(path.Join(in.dir, in.planFileName), nil)
+
+	in.variablesFileName = "plural.auto.tfvars.json"
+	helpers.EnsureFileOrDie(path.Join(in.dir, in.variablesFileName), in.variables)
 
 	return in
 }
 
 // New creates a Terraform structure that implements v1.Tool interface.
-func New(dir string) v1.Tool {
-	return (&Terraform{dir: dir}).init()
+func New(dir string, variables *string) v1.Tool {
+	return (&Terraform{dir: dir, variables: variables}).init()
 }

--- a/pkg/harness/tool/terraform/terraform_types.go
+++ b/pkg/harness/tool/terraform/terraform_types.go
@@ -8,4 +8,12 @@ type Terraform struct {
 	// planFileName is a terraform plan file name.
 	// Default: terraform.tfplan
 	planFileName string
+
+	// variablesFileName is a terraform variables file name.
+	// Default: plural.auto.tfvars.json
+	variablesFileName string
+
+	// variables is a JSON encoded string representing
+	// terraform variable file.
+	variables *string
 }

--- a/pkg/harness/tool/tool.go
+++ b/pkg/harness/tool/tool.go
@@ -11,14 +11,14 @@ import (
 
 // New creates a specific tool implementation structure based on the provided
 // gqlclient.StackType.
-func New(stackType console.StackType, workDir, execDir string) v1.Tool {
+func New(stackType console.StackType, workDir, execDir string, variables *string) v1.Tool {
 	var t v1.Tool
 
 	switch stackType {
 	case console.StackTypeTerraform:
-		t = terraform.New(execDir)
+		t = terraform.New(execDir, variables)
 	case console.StackTypeAnsible:
-		t = ansible.New(workDir, execDir)
+		t = ansible.New(workDir, execDir, variables)
 	case console.StackTypeCustom:
 		t = v1.New()
 	default:

--- a/pkg/harness/tool/tool.go
+++ b/pkg/harness/tool/tool.go
@@ -18,7 +18,7 @@ func New(stackType console.StackType, workDir, execDir string, variables *string
 	case console.StackTypeTerraform:
 		t = terraform.New(execDir, variables)
 	case console.StackTypeAnsible:
-		t = ansible.New(workDir, execDir, variables)
+		t = ansible.New(workDir, execDir)
 	case console.StackTypeCustom:
 		t = v1.New()
 	default:


### PR DESCRIPTION
Tested with the following stack.

### Terraform (main.tf)
```terraform
resource "random_string" "random" {
  length  = var.random_string_length
  upper   = var.random_string_upper
  special = var.random_string_special
}

resource "null_resource" "default" {
  provisioner "local-exec" {
    command = "${var.null_resource_command} ${random_string.random.result}"
  }
}

output "test" {
  value = random_string.random.result
}
```

### Terraform (variables.tf)
```terraform
variable "random_string_length" {
  type = number
  default = 5
}

variable "random_string_upper" {
  type = bool
  default = false
}

variable "random_string_special" {
  type = bool
  default = false
}

variable "null_resource_command" {
  type = string
  default = "echo"
}
```

### InfrastructureStack CRD
```yaml
apiVersion: deployments.plural.sh/v1alpha1
kind: InfrastructureStack
metadata:
  name: floreks-stack-variables-basic
  namespace: default
spec:
  detach: true
  type: TERRAFORM
  approval: true
  workdir: variables
  configuration:
    image: ghcr.io/pluralsh/harness
    version: sha-e9b2089-terraform-1.8
  repositoryRef:
    name: tf-test
    namespace: default
  clusterRef:
    name: existing
    namespace: default
  git:
    ref: main
    folder: terraform
  variables:
    random_string_length: 10
    random_string_upper: true
    null_resource_command: "echo prefix-"
```