### PR TITLE
fix(upgradeinsights): use ec2imds region resolver to create aws client

### DIFF
--- a/internal/controller/upgradeinsights_cloudprovider.go
+++ b/internal/controller/upgradeinsights_cloudprovider.go
@@ -146,7 +146,7 @@ func (in *EKSCloudProvider) toInsightDetails(insight *types.Insight) []*console.
 func (in *EKSCloudProvider) config(ctx context.Context, ui v1alpha1.UpgradeInsights) (aws.Config, error) {
 	// If credentials are not provided in the request, then use default credentials.
 	if ui.Spec.Credentials == nil || ui.Spec.Credentials.AWS == nil {
-		return awsconfig.LoadDefaultConfig(ctx, awsconfig.WithDefaultsMode(aws.DefaultsModeAuto))
+		return awsconfig.LoadDefaultConfig(ctx, awsconfig.WithEC2IMDSRegion())
 	}
 
 	// Otherwise use provided credentials.

--- a/internal/controller/upgradeinsights_cloudprovider.go
+++ b/internal/controller/upgradeinsights_cloudprovider.go
@@ -146,7 +146,7 @@ func (in *EKSCloudProvider) toInsightDetails(insight *types.Insight) []*console.
 func (in *EKSCloudProvider) config(ctx context.Context, ui v1alpha1.UpgradeInsights) (aws.Config, error) {
 	// If credentials are not provided in the request, then use default credentials.
 	if ui.Spec.Credentials == nil || ui.Spec.Credentials.AWS == nil {
-		return awsconfig.LoadDefaultConfig(ctx)
+		return awsconfig.LoadDefaultConfig(ctx, awsconfig.WithDefaultsMode(aws.DefaultsModeAuto))
 	}
 
 	// Otherwise use provided credentials.


### PR DESCRIPTION
This should force aws client to fallback to using ec2 metadata service if running inside the aws.