### PR TITLE
chore: improve Vulnerability Report Reconciler

### DIFF
--- a/internal/controller/vulnerabilityreports_controller.go
+++ b/internal/controller/vulnerabilityreports_controller.go
@@ -43,6 +43,7 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	if !vulnerabilityReport.DeletionTimestamp.IsZero() {
+		r.reports.Remove(req.NamespacedName.String())
 		return ctrl.Result{}, nil
 	}
 
@@ -203,7 +204,6 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 				logger.Error(err, "unable to upsert vulnerability reports")
 			} else {
 				logger.Info("upsert vulnerability reports")
-				r.reports.Clear()
 			}
 		}
 		return false, nil


### PR DESCRIPTION
Keep the full set in memory and append it to that set, only remove it from that set when a reconcile fires with a deletionTimestamp set.