### PR TITLE
feat: get node and control plane costs

### DIFF
--- a/cmd/agent/args/args.go
+++ b/cmd/agent/args/args.go
@@ -57,6 +57,7 @@ var (
 	argLocal                           = flag.Bool("local", false, "Whether you're running the operator locally.")
 	argProfiler                        = flag.Bool("profiler", false, "Enable pprof handler. By default it will be exposed on localhost:7777 under '/debug/pprof'")
 	argDisableResourceCache            = flag.Bool("disable-resource-cache", false, "Control whether resource cache should be enabled or not.")
+	argEnableKubecostProxy             = flag.Bool("enable-kubecost-proxy", false, "If set, will proxy a Kubecost API request through the K8s API server.")
 
 	argMaxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 20, "Maximum number of concurrent reconciles which can be run.")
 	argResyncSeconds           = flag.Int("resync-seconds", 300, "Resync duration in seconds.")
@@ -110,6 +111,10 @@ func Init() {
 
 func DisableHelmTemplateDryRunServer() bool {
 	return *argDisableHelmTemplateDryRunServer
+}
+
+func EnableKubecostProxy() bool {
+	return *argEnableKubecostProxy
 }
 
 func EnableHelmDependencyUpdate() bool {

--- a/cmd/agent/kubernetes.go
+++ b/cmd/agent/kubernetes.go
@@ -102,6 +102,7 @@ func registerKubeReconcilersOrDie(
 	config *rest.Config,
 	extConsoleClient consoleclient.Client,
 	discoveryClient discovery.DiscoveryInterface,
+	enableKubecostProxy bool,
 ) {
 
 	rolloutsClient, dynamicClient, kubeClient, metricsClient := initKubeClientsOrDie(config)
@@ -250,6 +251,7 @@ func registerKubeReconcilersOrDie(
 		KubeClient:       kubeClient,
 		ExtConsoleClient: extConsoleClient,
 		Tasks:            cmap.New[context.CancelFunc](),
+		Proxy:            enableKubecostProxy,
 	}).SetupWithManager(manager); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MetricsAggregate")
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -61,7 +61,7 @@ func main() {
 	cache.InitGateCache(args.ControllerCacheTTL(), extConsoleClient)
 
 	registerConsoleReconcilersOrDie(consoleManager, config, kubeManager.GetClient(), kubeManager.GetScheme(), extConsoleClient)
-	registerKubeReconcilersOrDie(ctx, kubeManager, consoleManager, config, extConsoleClient, discoveryClient)
+	registerKubeReconcilersOrDie(ctx, kubeManager, consoleManager, config, extConsoleClient, discoveryClient, args.EnableKubecostProxy())
 
 	//+kubebuilder:scaffold:builder
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/opencost/opencost/core v0.0.0-20241216191657-30e5d9a27f41
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console/go/client v1.25.2
+	github.com/pluralsh/console/go/client v1.25.3
 	github.com/pluralsh/controller-reconcile-helper v0.1.0
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -1190,8 +1190,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pluralsh/console/go/client v1.25.2 h1:Ha/ZF5t+ilJ0MVZPeDO46tK7HyKmi74c1DIHPA2sDY0=
-github.com/pluralsh/console/go/client v1.25.2/go.mod h1:lpoWASYsM9keNePS3dpFiEisUHEfObIVlSL3tzpKn8k=
+github.com/pluralsh/console/go/client v1.25.3 h1:6MvNz0AuxGwH+zWQyXakMCKf/UG8YfalZBLED9pWLoU=
+github.com/pluralsh/console/go/client v1.25.3/go.mod h1:lpoWASYsM9keNePS3dpFiEisUHEfObIVlSL3tzpKn8k=
 github.com/pluralsh/controller-reconcile-helper v0.1.0 h1:BV3dYZFH5rn8ZvZjtpkACSv/GmLEtRftNQj/Y4ddHEo=
 github.com/pluralsh/controller-reconcile-helper v0.1.0/go.mod h1:RxAbvSB4/jkvx616krCdNQXPbpGJXW3J1L3rASxeFOA=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=

--- a/internal/controller/kubecostextractor_controller.go
+++ b/internal/controller/kubecostextractor_controller.go
@@ -73,7 +73,7 @@ func (r *KubecostExtractorReconciler) RunOnInterval(ctx context.Context, key str
 	r.Tasks.Set(key, cancel)
 
 	go func() {
-		_ = wait.PollUntilContextCancel(ctxCancel, interval+time.Duration(rand.Int63n(int64(kubeCostJitter))), true, condition)
+		_ = wait.PollUntilContextCancel(ctxCancel, interval, true, condition)
 	}()
 }
 
@@ -132,6 +132,7 @@ func (r *KubecostExtractorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	r.RunOnInterval(ctx, req.NamespacedName.String(), kubecost.Spec.GetInterval(), func(ctx context.Context) (done bool, err error) {
+		time.Sleep(time.Duration(rand.Int63n(int64(kubeCostJitter))))
 		// Always patch object when exiting this function, so we can persist any object changes.
 		defer func() {
 			if err := scope.PatchObject(); err != nil && reterr == nil {


### PR DESCRIPTION
- add nodeCost and controlPlaneCost to cluster cost scrapes
- add jitter to kubecost extraction
- add `enable-kubecost-proxy` flag