### PR TITLE
chore: bump agentk version in helm chart

### DIFF
--- a/charts/deployment-operator/Chart.yaml
+++ b/charts/deployment-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: deployment-operator
 description: creates a new instance of the plural deployment operator
 appVersion: 0.5.6
-version: 0.5.6
+version: 0.5.7
 maintainers:
   - name: Plural
     url: https://www.plural.sh

--- a/charts/deployment-operator/Chart.yaml
+++ b/charts/deployment-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: deployment-operator
 description: creates a new instance of the plural deployment operator
 appVersion: 0.5.6
-version: 0.5.7
+version: 0.5.6
 maintainers:
   - name: Plural
     url: https://www.plural.sh

--- a/charts/deployment-operator/values.yaml
+++ b/charts/deployment-operator/values.yaml
@@ -101,7 +101,7 @@ agentk:
     repository: ghcr.io/pluralsh/agentk
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.0.1
+    tag: 0.0.2
   config:
     kasAddress: ""
     # kasHeaders:


### PR DESCRIPTION
Bump agentk to the latest version `0.0.2` with fixed CVE's