### PR TITLE
feat: extend eks upgrade insights with addons information

### DIFF
--- a/api/v1alpha1/virtualcluster_types.go
+++ b/api/v1alpha1/virtualcluster_types.go
@@ -273,5 +273,6 @@ func (in *VirtualClusterStatus) IsVClusterReady() bool {
 }
 
 func (in *VirtualClusterStatus) IsAgentReady() bool {
+	metav1.NewControllerRef()
 	return meta.IsStatusConditionTrue(in.Conditions, AgentConditionType.String())
 }

--- a/api/v1alpha1/virtualcluster_types.go
+++ b/api/v1alpha1/virtualcluster_types.go
@@ -273,6 +273,5 @@ func (in *VirtualClusterStatus) IsVClusterReady() bool {
 }
 
 func (in *VirtualClusterStatus) IsAgentReady() bool {
-	metav1.NewControllerRef()
 	return meta.IsStatusConditionTrue(in.Conditions, AgentConditionType.String())
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/opencost/opencost/core v0.0.0-20241216191657-30e5d9a27f41
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console/go/client v1.26.2
+	github.com/pluralsh/console/go/client v1.27.0
 	github.com/pluralsh/controller-reconcile-helper v0.1.0
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pluralsh/console/go/client v1.26.2 h1:i8XVkr4jKTuZJpQerjk7OB2qCDxZGboBiEhoweAvOCs=
-github.com/pluralsh/console/go/client v1.26.2/go.mod h1:lpoWASYsM9keNePS3dpFiEisUHEfObIVlSL3tzpKn8k=
+github.com/pluralsh/console/go/client v1.27.0 h1:qQ8+1kPHdPXeaTUnR91wZAmg6Q8k+I9XY3Ji6/rvWvY=
+github.com/pluralsh/console/go/client v1.27.0/go.mod h1:lpoWASYsM9keNePS3dpFiEisUHEfObIVlSL3tzpKn8k=
 github.com/pluralsh/controller-reconcile-helper v0.1.0 h1:BV3dYZFH5rn8ZvZjtpkACSv/GmLEtRftNQj/Y4ddHEo=
 github.com/pluralsh/controller-reconcile-helper v0.1.0/go.mod h1:RxAbvSB4/jkvx616krCdNQXPbpGJXW3J1L3rASxeFOA=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=

--- a/internal/controller/upgradeinsights_controller.go
+++ b/internal/controller/upgradeinsights_controller.go
@@ -106,12 +106,12 @@ func (in *UpgradeInsightsController) sync(ctx context.Context, ui *v1alpha1.Upgr
 		return err
 	}
 
-	attributes, err := cloudProvider.UpgradeInsights(ctx, *ui)
+	attributes, addons, err := cloudProvider.UpgradeInsights(ctx, *ui)
 	if err != nil {
 		return err
 	}
 
-	_, err = in.ConsoleClient.SaveUpgradeInsights(lo.ToSlicePtr(attributes))
+	_, err = in.ConsoleClient.SaveUpgradeInsights(lo.ToSlicePtr(attributes), lo.ToSlicePtr(addons))
 	return err
 }
 

--- a/pkg/client/console.go
+++ b/pkg/client/console.go
@@ -69,7 +69,7 @@ type Client interface {
 	ListClusterStackRuns(after *string, first *int64) (*console.ListClusterStackIds_ClusterStackRuns, error)
 	GetUser(email string) (*console.UserFragment, error)
 	GetGroup(name string) (*console.GroupFragment, error)
-	SaveUpgradeInsights(attributes []*console.UpgradeInsightAttributes) (*console.SaveUpgradeInsights, error)
+	SaveUpgradeInsights(attributes []*console.UpgradeInsightAttributes, addons []*console.CloudAddonAttributes) (*console.SaveUpgradeInsights, error)
 	UpsertVulnerabilityReports(vulnerabilities []*console.VulnerabilityReportAttributes) (*console.UpsertVulnerabilities, error)
 	IngestClusterCost(attr console.CostIngestAttributes) (*console.IngestClusterCost, error)
 }

--- a/pkg/client/upgradeinsights.go
+++ b/pkg/client/upgradeinsights.go
@@ -4,6 +4,6 @@ import (
 	console "github.com/pluralsh/console/go/client"
 )
 
-func (c *client) SaveUpgradeInsights(attributes []*console.UpgradeInsightAttributes) (*console.SaveUpgradeInsights, error) {
-	return c.consoleClient.SaveUpgradeInsights(c.ctx, attributes)
+func (c *client) SaveUpgradeInsights(attributes []*console.UpgradeInsightAttributes, addons []*console.CloudAddonAttributes) (*console.SaveUpgradeInsights, error) {
+	return c.consoleClient.SaveUpgradeInsights(c.ctx, attributes, addons)
 }

--- a/pkg/harness/signals/context.go
+++ b/pkg/harness/signals/context.go
@@ -6,6 +6,8 @@ import (
 
 type cancelableContext struct {
 	context.Context
+
+	Cancel context.CancelCauseFunc
 }
 
 func NewCancelableContext(parent context.Context, signals ...Signal) context.Context {
@@ -20,5 +22,6 @@ func NewCancelableContext(parent context.Context, signals ...Signal) context.Con
 
 	return &cancelableContext{
 		Context: ctx,
+		Cancel:  cancel,
 	}
 }

--- a/pkg/test/mocks/Client_mock.go
+++ b/pkg/test/mocks/Client_mock.go
@@ -1615,9 +1615,9 @@ func (_c *ClientMock_SaveClusterBackup_Call) RunAndReturn(run func(client.Backup
 	return _c
 }
 
-// SaveUpgradeInsights provides a mock function with given fields: attributes
-func (_m *ClientMock) SaveUpgradeInsights(attributes []*client.UpgradeInsightAttributes) (*client.SaveUpgradeInsights, error) {
-	ret := _m.Called(attributes)
+// SaveUpgradeInsights provides a mock function with given fields: attributes, addons
+func (_m *ClientMock) SaveUpgradeInsights(attributes []*client.UpgradeInsightAttributes, addons []*client.CloudAddonAttributes) (*client.SaveUpgradeInsights, error) {
+	ret := _m.Called(attributes, addons)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveUpgradeInsights")
@@ -1625,19 +1625,19 @@ func (_m *ClientMock) SaveUpgradeInsights(attributes []*client.UpgradeInsightAtt
 
 	var r0 *client.SaveUpgradeInsights
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]*client.UpgradeInsightAttributes) (*client.SaveUpgradeInsights, error)); ok {
-		return rf(attributes)
+	if rf, ok := ret.Get(0).(func([]*client.UpgradeInsightAttributes, []*client.CloudAddonAttributes) (*client.SaveUpgradeInsights, error)); ok {
+		return rf(attributes, addons)
 	}
-	if rf, ok := ret.Get(0).(func([]*client.UpgradeInsightAttributes) *client.SaveUpgradeInsights); ok {
-		r0 = rf(attributes)
+	if rf, ok := ret.Get(0).(func([]*client.UpgradeInsightAttributes, []*client.CloudAddonAttributes) *client.SaveUpgradeInsights); ok {
+		r0 = rf(attributes, addons)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.SaveUpgradeInsights)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]*client.UpgradeInsightAttributes) error); ok {
-		r1 = rf(attributes)
+	if rf, ok := ret.Get(1).(func([]*client.UpgradeInsightAttributes, []*client.CloudAddonAttributes) error); ok {
+		r1 = rf(attributes, addons)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1652,13 +1652,14 @@ type ClientMock_SaveUpgradeInsights_Call struct {
 
 // SaveUpgradeInsights is a helper method to define mock.On call
 //   - attributes []*client.UpgradeInsightAttributes
-func (_e *ClientMock_Expecter) SaveUpgradeInsights(attributes interface{}) *ClientMock_SaveUpgradeInsights_Call {
-	return &ClientMock_SaveUpgradeInsights_Call{Call: _e.mock.On("SaveUpgradeInsights", attributes)}
+//   - addons []*client.CloudAddonAttributes
+func (_e *ClientMock_Expecter) SaveUpgradeInsights(attributes interface{}, addons interface{}) *ClientMock_SaveUpgradeInsights_Call {
+	return &ClientMock_SaveUpgradeInsights_Call{Call: _e.mock.On("SaveUpgradeInsights", attributes, addons)}
 }
 
-func (_c *ClientMock_SaveUpgradeInsights_Call) Run(run func(attributes []*client.UpgradeInsightAttributes)) *ClientMock_SaveUpgradeInsights_Call {
+func (_c *ClientMock_SaveUpgradeInsights_Call) Run(run func(attributes []*client.UpgradeInsightAttributes, addons []*client.CloudAddonAttributes)) *ClientMock_SaveUpgradeInsights_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]*client.UpgradeInsightAttributes))
+		run(args[0].([]*client.UpgradeInsightAttributes), args[1].([]*client.CloudAddonAttributes))
 	})
 	return _c
 }
@@ -1668,7 +1669,7 @@ func (_c *ClientMock_SaveUpgradeInsights_Call) Return(_a0 *client.SaveUpgradeIns
 	return _c
 }
 
-func (_c *ClientMock_SaveUpgradeInsights_Call) RunAndReturn(run func([]*client.UpgradeInsightAttributes) (*client.SaveUpgradeInsights, error)) *ClientMock_SaveUpgradeInsights_Call {
+func (_c *ClientMock_SaveUpgradeInsights_Call) RunAndReturn(run func([]*client.UpgradeInsightAttributes, []*client.CloudAddonAttributes) (*client.SaveUpgradeInsights, error)) *ClientMock_SaveUpgradeInsights_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
It scrapes addons information from the EKS cluster and uses updated `saveUpgradeInsights` API to send it to Console.