### PR TITLE
fix: Only apply stale-if-fail health checks to whitelisted gvks

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -22,7 +22,8 @@ func ToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 		return nil, err
 	}
 
-	return &unstructured.Unstructured{Object: objMap}, nil
+	unstructured := &unstructured.Unstructured{Object: objMap}
+	return unstructured, nil
 }
 
 func Unmarshal(s string) (map[string]interface{}, error) {

--- a/pkg/common/health_test.go
+++ b/pkg/common/health_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Health Test", Ordered, func() {
 				},
 			}
 			obj, err := common.ToUnstructured(customResource)
+			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
+			obj.SetKind("MetricsAggregate")
 			Expect(err).NotTo(HaveOccurred())
 			status, err := common.GetResourceHealth(obj)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This can prevent the ui from overfailing resources/services