### PR TITLE
fix(harness): do not send an error if stack run was cancelled

### DIFF
--- a/pkg/harness/controller/controller_hooks.go
+++ b/pkg/harness/controller/controller_hooks.go
@@ -47,6 +47,8 @@ func (in *stackRunController) postStart(err error) {
 		status = gqlclient.StackStatusSuccessful
 	case errors.Is(err, internalerrors.ErrRemoteCancel):
 		status = gqlclient.StackStatusCancelled
+		// Do not send an error if stack run was cancelled
+		err = nil
 	default:
 		status = gqlclient.StackStatusFailed
 	}


### PR DESCRIPTION
<p><a href="https://linear.app/pluralsh/issue/PROD-3218/harness-shouldnt-set-service-errors-when-stack-is-cancelled">PROD-3218</a></p>