### PR TITLE
feat: add service mesh discovery to operational layout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/opencost/opencost/core v0.0.0-20241216191657-30e5d9a27f41
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console/go/client v1.32.0
+	github.com/pluralsh/console/go/client v1.32.1
 	github.com/pluralsh/controller-reconcile-helper v0.1.0
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -1736,8 +1736,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
-github.com/pluralsh/console/go/client v1.32.0 h1:V/VoiohHmhdwmPxQBDoF167yoau8jGWV+sxXV90dCgk=
-github.com/pluralsh/console/go/client v1.32.0/go.mod h1:ZDRhjfDzbFLrHCfP3k6SaLlTDcjALCL8KIKQCYIHSJM=
+github.com/pluralsh/console/go/client v1.32.1 h1:/FCgrfdfq/iqEGAY9zkalhoYbdncQPt4sBL2Ay5o5zE=
+github.com/pluralsh/console/go/client v1.32.1/go.mod h1:ZDRhjfDzbFLrHCfP3k6SaLlTDcjALCL8KIKQCYIHSJM=
 github.com/pluralsh/controller-reconcile-helper v0.1.0 h1:BV3dYZFH5rn8ZvZjtpkACSv/GmLEtRftNQj/Y4ddHEo=
 github.com/pluralsh/controller-reconcile-helper v0.1.0/go.mod h1:RxAbvSB4/jkvx616krCdNQXPbpGJXW3J1L3rASxeFOA=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=

--- a/pkg/cache/discovery_cache.go
+++ b/pkg/cache/discovery_cache.go
@@ -3,19 +3,40 @@ package cache
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	cmap "github.com/orcaman/concurrent-map/v2"
-	"github.com/pluralsh/deployment-operator/internal/helpers"
-	"github.com/pluralsh/deployment-operator/internal/metrics"
+	"github.com/pluralsh/console/go/client"
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
+
+	"github.com/pluralsh/deployment-operator/internal/helpers"
+	"github.com/pluralsh/deployment-operator/internal/metrics"
+)
+
+const (
+	// ServiceMeshResourceGroupIstio is a base group name used by Istio
+	// Ref: https://github.com/istio/istio/blob/6186a80cb220ecbd7e1cc82044fe3a6fc2876c63/operator/pkg/apis/register.go#L27-L31
+	ServiceMeshResourceGroupIstio string = "istio.io"
+
+	// ServiceMeshResourceGroupCilium is a base group name used by Cilium
+	// Ref: https://github.com/cilium/cilium/blob/99b4bc0d0b628f22c024f3ea74ef21007a831f52/pkg/k8s/apis/cilium.io/register.go#L7-L8
+	ServiceMeshResourceGroupCilium string = "cilium.io"
+
+	// ServiceMeshResourceGroupLinkerd is a base group name used by Linkerd
+	// Ref: https://github.com/linkerd/linkerd2/blob/e055c32f31ae7618281fed1eb5c304b0d1389a52/controller/gen/apis/serviceprofile/register.go#L3-L4
+	ServiceMeshResourceGroupLinkerd string = "linkerd.io"
 )
 
 var (
 	// Maps a GroupVersion to resource Kind.
-	discoveryCache cmap.ConcurrentMap[string, bool]
+	discoveryCache    cmap.ConcurrentMap[string, bool]
+	serviceMesh       = ""
+	serviceMeshRWLock = sync.RWMutex{}
 )
 
 func init() {
@@ -24,6 +45,22 @@ func init() {
 
 func DiscoveryCache() cmap.ConcurrentMap[string, bool] {
 	return discoveryCache
+}
+
+func ServiceMesh() *client.ServiceMesh {
+	serviceMeshRWLock.RLock()
+	defer serviceMeshRWLock.RUnlock()
+
+	switch serviceMesh {
+	case ServiceMeshResourceGroupIstio:
+		return lo.ToPtr(client.ServiceMeshIstio)
+	case ServiceMeshResourceGroupCilium:
+		return lo.ToPtr(client.ServiceMeshCilium)
+	case ServiceMeshResourceGroupLinkerd:
+		return lo.ToPtr(client.ServiceMeshLinkerd)
+	default:
+		return nil
+	}
 }
 
 func RunDiscoveryCacheInBackgroundOrDie(ctx context.Context, discoveryClient *discovery.DiscoveryClient) {
@@ -61,8 +98,26 @@ func updateDiscoveryCache(discoveryClient *discovery.DiscoveryClient) error {
 
 			discoveryCache.Set(fmt.Sprintf("%s/%s", gv.String(), resource.Kind), true)
 			discoveryCache.Set(gv.String(), true)
+
+			checkAndUpdateServiceMesh(gv.Group)
 		}
 	}
 
 	return err
+}
+
+func checkAndUpdateServiceMesh(group string) {
+	serviceMeshRWLock.Lock()
+	defer serviceMeshRWLock.Unlock()
+
+	switch {
+	case strings.Contains(group, ServiceMeshResourceGroupIstio):
+		serviceMesh = ServiceMeshResourceGroupIstio
+		break
+	case strings.Contains(group, ServiceMeshResourceGroupCilium):
+		serviceMesh = ServiceMeshResourceGroupCilium
+		break
+	case strings.Contains(group, ServiceMeshResourceGroupLinkerd):
+		serviceMesh = ServiceMeshResourceGroupLinkerd
+	}
 }

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	console "github.com/pluralsh/console/go/client"
-	internalerrors "github.com/pluralsh/deployment-operator/internal/errors"
 	"github.com/pluralsh/polly/containers"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	internalerrors "github.com/pluralsh/deployment-operator/internal/errors"
 )
 
 const (
@@ -45,7 +46,7 @@ func appendUniqueExternalDNSNamespace(slice []*string, newValue *string) []*stri
 	return sliceSet.List()
 }
 
-func (c *client) RegisterRuntimeServices(svcs map[string]*NamespaceVersion, serviceId *string) error {
+func (c *client) RegisterRuntimeServices(svcs map[string]*NamespaceVersion, serviceId *string, serviceMesh *console.ServiceMesh) error {
 	inputs := make([]*console.RuntimeServiceAttributes, 0)
 	var layouts *console.OperationalLayoutAttributes
 	for name, nv := range svcs {
@@ -79,6 +80,7 @@ func (c *client) RegisterRuntimeServices(svcs map[string]*NamespaceVersion, serv
 		}
 	}
 
+	layouts.ServiceMesh = serviceMesh
 	_, err := c.consoleClient.RegisterRuntimeServices(c.ctx, inputs, layouts, serviceId)
 	return err
 }

--- a/pkg/client/console.go
+++ b/pkg/client/console.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	console "github.com/pluralsh/console/go/client"
+
 	"github.com/pluralsh/deployment-operator/api/v1alpha1"
 	"github.com/pluralsh/deployment-operator/internal/helpers"
 	v1 "github.com/pluralsh/deployment-operator/pkg/harness/stackrun/v1"
@@ -42,7 +43,7 @@ type Client interface {
 	GetCredentials() (url, token string)
 	PingCluster(attributes console.ClusterPing) error
 	Ping(vsn string) error
-	RegisterRuntimeServices(svcs map[string]*NamespaceVersion, serviceId *string) error
+	RegisterRuntimeServices(svcs map[string]*NamespaceVersion, serviceId *string, serviceMesh *console.ServiceMesh) error
 	UpsertVirtualCluster(parentID string, attributes console.ClusterAttributes) (*console.GetClusterWithToken_Cluster, error)
 	IsClusterExists(id string) (bool, error)
 	GetCluster(id string) (*console.TinyClusterFragment, error)

--- a/pkg/controller/service/reconciler_scraper.go
+++ b/pkg/controller/service/reconciler_scraper.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pluralsh/deployment-operator/pkg/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/pluralsh/deployment-operator/pkg/cache"
+	"github.com/pluralsh/deployment-operator/pkg/client"
 )
 
 func (s *ServiceReconciler) ScrapeKube(ctx context.Context) {
@@ -37,7 +39,8 @@ func (s *ServiceReconciler) ScrapeKube(ctx context.Context) {
 			AddRuntimeServiceInfo(ds.Namespace, ds.GetLabels(), runtimeServices)
 		}
 	}
-	if err := s.consoleClient.RegisterRuntimeServices(runtimeServices, nil); err != nil {
+
+	if err := s.consoleClient.RegisterRuntimeServices(runtimeServices, nil, cache.ServiceMesh()); err != nil {
 		logger.Error(err, "failed to register runtime services, this is an ignorable error but could mean your console needs to be upgraded")
 	}
 }


### PR DESCRIPTION
Added service mesh discovery to our cache package. It will be refreshed on every discovery cache refresh. Service mesh is detected based on the registered resource group names.