### PR TITLE
fix: delete manifest cache on service delete

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -364,6 +364,7 @@ func (s *ServiceReconciler) Reconcile(ctx context.Context, id string) (result re
 		})
 
 		metrics.Record().ServiceDeletion(id)
+		s.manifestCache.Expire(id)
 		err = s.UpdatePruneStatus(ctx, svc, ch, map[schema.GroupName]string{})
 		return
 	}

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -364,6 +364,7 @@ func (s *ServiceReconciler) Reconcile(ctx context.Context, id string) (result re
 		})
 
 		metrics.Record().ServiceDeletion(id)
+		s.svcCache.Expire(id)
 		s.manifestCache.Expire(id)
 		err = s.UpdatePruneStatus(ctx, svc, ch, map[schema.GroupName]string{})
 		return

--- a/pkg/manifests/cache.go
+++ b/pkg/manifests/cache.go
@@ -94,6 +94,10 @@ func (c *ManifestCache) Wipe() {
 }
 
 func (c *ManifestCache) Expire(id string) {
+	// cleanup manifests dir
+	if line, ok := c.cache.Get(id); ok {
+		line.wipe()
+	}
 	c.cache.Remove(id)
 }
 


### PR DESCRIPTION
We did not clear the cache when the service was deleted not from the UI.