### PR TITLE
fix: fetch pods status for pending Deployment,DaemonSet and StatefulSet

### DIFF
--- a/internal/utils/kubernetes.go
+++ b/internal/utils/kubernetes.go
@@ -58,7 +58,7 @@ func TryToUpdate(ctx context.Context, client ctrlruntimeclient.Client, object ct
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		original := object.DeepCopyObject().(ctrlruntimeclient.Object)
 		if err := client.Get(ctx, key, object); err != nil {
-			return fmt.Errorf("could not fetch current %s/%s state, got error: %+v", object.GetName(), object.GetNamespace(), err)
+			return fmt.Errorf("could not fetch current %s/%s state, got error: %w", object.GetName(), object.GetNamespace(), err)
 		}
 
 		if reflect.DeepEqual(object, original) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -49,7 +49,7 @@ func HasUnhealthyPods(ctx context.Context, k8sClient ctrclient.Client, owner *un
 		Kind:    "Pod",
 	})
 
-	labels, found, err := unstructured.NestedStringMap(owner.Object, "spec", "template", "metadata", "labels")
+	labels, found, err := unstructured.NestedStringMap(owner.Object, "spec", "selector", "matchLabels")
 	if err != nil || !found {
 		return false, nil
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,9 +1,14 @@
 package common
 
 import (
+	"context"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -33,4 +38,37 @@ func Unmarshal(s string) (map[string]interface{}, error) {
 	}
 
 	return result, nil
+}
+
+// HasUnhealthyPods Generic function to get Pods by owner (Deployment, DaemonSet, or StatefulSet)
+func HasUnhealthyPods(ctx context.Context, k8sClient ctrclient.Client, owner *unstructured.Unstructured) (bool, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	})
+
+	labels, found, err := unstructured.NestedStringMap(owner.Object, "spec", "template", "metadata", "labels")
+	if err != nil || !found {
+		return false, nil
+	}
+
+	ml := ctrclient.MatchingLabels(labels)
+
+	// Use the label selector to get Pods managed by the owner (Deployment, DaemonSet, or StatefulSet)
+	err = k8sClient.List(ctx, list, ml)
+	if err != nil {
+		return false, fmt.Errorf("failed to get pods for owner: %v", err)
+	}
+	for _, pod := range list.Items {
+		health, err := GetResourceHealth(&pod)
+		if err != nil {
+			return false, err
+		}
+		if health.Status == HealthStatusDegraded {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -59,7 +59,7 @@ func HasUnhealthyPods(ctx context.Context, k8sClient ctrclient.Client, owner *un
 	// Use the label selector to get Pods managed by the owner (Deployment, DaemonSet, or StatefulSet)
 	err = k8sClient.List(ctx, list, ml)
 	if err != nil {
-		return false, fmt.Errorf("failed to get pods for owner: %v", err)
+		return false, fmt.Errorf("failed to get pods for owner: %w", err)
 	}
 	for _, pod := range list.Items {
 		health, err := GetResourceHealth(&pod)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,14 +1,9 @@
 package common
 
 import (
-	"context"
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -38,40 +33,4 @@ func Unmarshal(s string) (map[string]interface{}, error) {
 	}
 
 	return result, nil
-}
-
-// HasUnhealthyPods Generic function to get Pods by owner (Deployment, DaemonSet, or StatefulSet)
-func HasUnhealthyPods(ctx context.Context, k8sClient ctrclient.Client, owner *unstructured.Unstructured) (bool, error) {
-	var opts []ctrclient.ListOption
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    "Pod",
-	})
-
-	labels, found, err := unstructured.NestedStringMap(owner.Object, "spec", "selector", "matchLabels")
-	if err != nil || !found {
-		return false, nil
-	}
-
-	ml := ctrclient.MatchingLabels(labels)
-	opts = append(opts, ml)
-	opts = append(opts, ctrclient.Limit(10))
-
-	// Use the label selector to get Pods managed by the owner (Deployment, DaemonSet, or StatefulSet)
-	err = k8sClient.List(ctx, list, opts...)
-	if err != nil {
-		return false, fmt.Errorf("failed to get pods for owner: %w", err)
-	}
-	for _, pod := range list.Items {
-		health, err := GetResourceHealth(&pod)
-		if err != nil {
-			return false, err
-		}
-		if health.Status == HealthStatusDegraded {
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -42,6 +42,7 @@ func Unmarshal(s string) (map[string]interface{}, error) {
 
 // HasUnhealthyPods Generic function to get Pods by owner (Deployment, DaemonSet, or StatefulSet)
 func HasUnhealthyPods(ctx context.Context, k8sClient ctrclient.Client, owner *unstructured.Unstructured) (bool, error) {
+	var opts []ctrclient.ListOption
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "",
@@ -55,9 +56,11 @@ func HasUnhealthyPods(ctx context.Context, k8sClient ctrclient.Client, owner *un
 	}
 
 	ml := ctrclient.MatchingLabels(labels)
+	opts = append(opts, ml)
+	opts = append(opts, ctrclient.Limit(10))
 
 	// Use the label selector to get Pods managed by the owner (Deployment, DaemonSet, or StatefulSet)
-	err = k8sClient.List(ctx, list, ml)
+	err = k8sClient.List(ctx, list, opts...)
 	if err != nil {
 		return false, fmt.Errorf("failed to get pods for owner: %w", err)
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,15 +1,22 @@
 package common
 
 import (
+	"context"
+	"time"
+
+	"github.com/pluralsh/deployment-operator/internal/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
 const (
-	ManagedByLabel  = "plural.sh/managed-by"
-	AgentLabelValue = "agent"
+	ManagedByLabel             = "plural.sh/managed-by"
+	AgentLabelValue            = "agent"
+	LastProgressTimeAnnotation = "plural.sh/last-progress-time"
 )
 
 func ManagedByAgentLabelSelector() labels.Selector {
@@ -33,4 +40,38 @@ func Unmarshal(s string) (map[string]interface{}, error) {
 	}
 
 	return result, nil
+}
+
+func GetLastProgressTimestamp(ctx context.Context, k8sClient ctrclient.Client, obj *unstructured.Unstructured) (progressTime metav1.Time, err error) {
+	progressTime = metav1.Now()
+
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(make(map[string]string))
+	}
+	annotations := obj.GetAnnotations()
+	timeStr, ok := annotations[LastProgressTimeAnnotation]
+
+	defer func() {
+		if !ok {
+			err = utils.TryToUpdate(ctx, k8sClient, obj)
+			if err != nil {
+				return
+			}
+			key := ctrclient.ObjectKeyFromObject(obj)
+			err = k8sClient.Get(ctx, key, obj)
+		}
+	}()
+
+	if !ok {
+		annotations[LastProgressTimeAnnotation] = progressTime.Time.Format(time.RFC3339)
+		obj.SetAnnotations(annotations)
+		return
+	}
+	parsedTime, err := time.Parse(time.RFC3339, timeStr)
+	if err != nil {
+		return
+	}
+	progressTime = metav1.Time{Time: parsedTime}
+
+	return
 }


### PR DESCRIPTION
We don't have complete information about those three workloads. They can be in a pending state forever, and we don't know this. The only way is to additionally check the pods' statuses. 