### PR TITLE
fix: resource health status

### DIFF
--- a/cmd/agent/console.go
+++ b/cmd/agent/console.go
@@ -54,7 +54,7 @@ func registerConsoleReconcilersOrDie(
 	consoleClient client.Client,
 ) {
 	mgr.AddReconcilerOrDie(service.Identifier, func() (v1.Reconciler, error) {
-		r, err := service.NewServiceReconciler(consoleClient, config, args.ControllerCacheTTL(), args.ManifestCacheTTL(), args.RestoreNamespace(), args.ConsoleUrl())
+		r, err := service.NewServiceReconciler(k8sClient, consoleClient, config, args.ControllerCacheTTL(), args.ManifestCacheTTL(), args.RestoreNamespace(), args.ConsoleUrl())
 		return r, err
 	})
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	// Start resource cache in background if enabled.
 	if args.ResourceCacheEnabled() {
-		cache.Init(ctx, config, args.ResourceCacheTTL())
+		cache.Init(ctx, kubeManager.GetClient(), config, args.ResourceCacheTTL())
 	}
 
 	// Start the discovery cache in background.

--- a/internal/controller/clusterdrain_controller.go
+++ b/internal/controller/clusterdrain_controller.go
@@ -235,7 +235,7 @@ func waitForHealthStatus(ctx context.Context, c client.Client, obj *unstructured
 			}
 
 			// Check the status of the object
-			status := common.ToStatus(obj)
+			status := common.ToStatus(ctx, c, obj)
 			if status == nil {
 				return fmt.Errorf("status is nil")
 			}

--- a/pkg/applier/filters/cache_filter_test.go
+++ b/pkg/applier/filters/cache_filter_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Test filters", func() {
 		}
 
 		It("check cache filter", func() {
-			cache.Init(context.Background(), cfg, 100*time.Second)
+			cache.Init(context.Background(), kClient, cfg, 100*time.Second)
 			cacheFilter := CacheFilter{}
 			res, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pod)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/cache/resource_cache_entry.go
+++ b/pkg/cache/resource_cache_entry.go
@@ -1,12 +1,14 @@
 package cache
 
 import (
-	console "github.com/pluralsh/console/go/client"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"context"
 
+	console "github.com/pluralsh/console/go/client"
 	"github.com/pluralsh/deployment-operator/internal/kubernetes/schema"
 	"github.com/pluralsh/deployment-operator/pkg/common"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type SHAType string
@@ -80,6 +82,6 @@ func (in *ResourceCacheEntry) RequiresApply(manifestSHA string) bool {
 
 // SetStatus saves the last seen resource [event.StatusEvent] and converts it to a simpler
 // [console.ComponentAttributes] structure.
-func (in *ResourceCacheEntry) SetStatus(se event.StatusEvent) {
-	in.status = common.StatusEventToComponentAttributes(se, make(map[schema.GroupName]string))
+func (in *ResourceCacheEntry) SetStatus(ctx context.Context, k8sClient ctrclient.Client, se event.StatusEvent) {
+	in.status = common.StatusEventToComponentAttributes(ctx, k8sClient, se, make(map[schema.GroupName]string))
 }

--- a/pkg/cache/resource_cache_test.go
+++ b/pkg/cache/resource_cache_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Resource cache", Ordered, func() {
 		})
 
 		It("should successfully create resource cache", func() {
-			Init(ctx, cfg, 100*time.Second)
+			Init(ctx, kClient, cfg, 100*time.Second)
 			toAdd := containers.NewSet[ResourceKey]()
 
 			// register resource and watch for changes
@@ -129,7 +129,7 @@ var _ = Describe("Resource cache", Ordered, func() {
 		})
 
 		It("should successfully watch CRD object", func() {
-			Init(ctx, cfg, 100*time.Second)
+			Init(ctx, kClient, cfg, 100*time.Second)
 			toAdd := containers.NewSet[ResourceKey]()
 
 			err = applyYamlFile(ctx, kClient, "../../config/crd/bases/deployments.plural.sh_customhealths.yaml")

--- a/pkg/common/health_test.go
+++ b/pkg/common/health_test.go
@@ -1,6 +1,7 @@
 package common_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"time"
@@ -9,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	deploymentsv1alpha1 "github.com/pluralsh/deployment-operator/api/v1alpha1"
 	"github.com/pluralsh/deployment-operator/pkg/common"
+	testcommon "github.com/pluralsh/deployment-operator/pkg/test/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -16,14 +18,21 @@ var _ = Describe("Health Test", Ordered, func() {
 	Context("Test health functions", func() {
 		customResource := &deploymentsv1alpha1.MetricsAggregate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
+				Name:      "test",
+				Namespace: "default",
 			},
 		}
 
+		BeforeAll(func() {
+			Expect(testcommon.MaybeCreate(kClient, customResource, nil)).To(Succeed())
+		})
+
 		It("should get default status from CRD without condition block", func() {
 			obj, err := common.ToUnstructured(customResource)
+			obj.SetKind("MetricsAggregate")
+			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
 			Expect(err).NotTo(HaveOccurred())
-			status, err := common.GetResourceHealth(obj)
+			status, err := common.GetResourceHealth(context.Background(), kClient, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Not(BeNil()))
 			Expect(*status).To(Equal(common.HealthStatus{
@@ -41,7 +50,9 @@ var _ = Describe("Health Test", Ordered, func() {
 			}
 			obj, err := common.ToUnstructured(customResource)
 			Expect(err).NotTo(HaveOccurred())
-			status, err := common.GetResourceHealth(obj)
+			obj.SetKind("MetricsAggregate")
+			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
+			status, err := common.GetResourceHealth(context.Background(), kClient, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Not(BeNil()))
 			Expect(*status).To(Equal(common.HealthStatus{
@@ -61,7 +72,9 @@ var _ = Describe("Health Test", Ordered, func() {
 			}
 			obj, err := common.ToUnstructured(customResource)
 			Expect(err).NotTo(HaveOccurred())
-			status, err := common.GetResourceHealth(obj)
+			obj.SetKind("MetricsAggregate")
+			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
+			status, err := common.GetResourceHealth(context.Background(), kClient, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Not(BeNil()))
 			Expect(*status).To(Equal(common.HealthStatus{
@@ -84,7 +97,7 @@ var _ = Describe("Health Test", Ordered, func() {
 			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
 			obj.SetKind("MetricsAggregate")
 			Expect(err).NotTo(HaveOccurred())
-			status, err := common.GetResourceHealth(obj)
+			status, err := common.GetResourceHealth(context.Background(), kClient, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Not(BeNil()))
 			Expect(*status).To(Equal(common.HealthStatus{
@@ -98,7 +111,9 @@ var _ = Describe("Health Test", Ordered, func() {
 			}
 			obj, err := common.ToUnstructured(customResource)
 			Expect(err).NotTo(HaveOccurred())
-			status, err := common.GetResourceHealth(obj)
+			obj.SetKind("MetricsAggregate")
+			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
+			status, err := common.GetResourceHealth(context.Background(), kClient, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Not(BeNil()))
 			Expect(*status).To(Equal(common.HealthStatus{
@@ -111,11 +126,13 @@ var _ = Describe("Health Test", Ordered, func() {
 			customResource.DeletionTimestamp = nil
 			obj, err := common.ToUnstructured(customResource)
 			Expect(err).NotTo(HaveOccurred())
+			obj.SetKind("MetricsAggregate")
+			obj.SetAPIVersion("deployments.plural.sh/v1alpha1")
 			scriptPath := filepath.Join("..", "..", "test", "lua", "test.lua")
 			script, err := os.ReadFile(scriptPath)
 			Expect(err).NotTo(HaveOccurred())
 			common.GetLuaScript().SetValue(string(script))
-			status, err := common.GetResourceHealth(obj)
+			status, err := common.GetResourceHealth(context.Background(), kClient, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Not(BeNil()))
 			Expect(*status).To(Equal(common.HealthStatus{

--- a/pkg/common/suite_test.go
+++ b/pkg/common/suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	deploymentsv1alpha1 "github.com/pluralsh/deployment-operator/api/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -46,6 +47,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases"), filepath.Join("..", "..", "test", "crd")},
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
 			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
@@ -53,6 +55,9 @@ var _ = BeforeSuite(func() {
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
+
+	err = deploymentsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	kClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/service/reconciler_status.go
+++ b/pkg/controller/service/reconciler_status.go
@@ -52,7 +52,7 @@ func (s *ServiceReconciler) UpdatePruneStatus(
 		return err
 	}
 
-	components := statusCollector.componentsAttributes(vcache)
+	components := statusCollector.componentsAttributes(ctx, s.k8sClient, vcache)
 	// delete service when components len == 0 (no new statuses, inventory file is empty, all deleted)
 	if err := s.UpdateStatus(svc.ID, svc.Revision.ID, svc.Sha, components, errorAttributes("sync", err)); err != nil {
 		logger.Error(err, "Failed to update service status, ignoring for now")
@@ -152,7 +152,7 @@ func (s *ServiceReconciler) UpdateApplyStatus(
 	if err := FormatSummary(ctx, svc.Namespace, svc.Name, statsCollector); err != nil {
 		return err
 	}
-	components := statusCollector.componentsAttributes(vcache)
+	components := statusCollector.componentsAttributes(ctx, s.k8sClient, vcache)
 	if err := s.UpdateStatus(svc.ID, svc.Revision.ID, svc.Sha, components, errorAttributes("sync", err)); err != nil {
 		logger.Error(err, "Failed to update service status, ignoring for now")
 	}

--- a/pkg/controller/service/reconciler_test.go
+++ b/pkg/controller/service/reconciler_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Reconciler", Ordered, func() {
 			fakeConsoleClient.On("GetService", mock.Anything).Return(consoleService, nil)
 			fakeConsoleClient.On("UpdateComponents", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-			reconciler, err := service.NewServiceReconciler(fakeConsoleClient, cfg, time.Minute, time.Minute, namespace, "http://localhost:8080")
+			reconciler, err := service.NewServiceReconciler(kClient, fakeConsoleClient, cfg, time.Minute, time.Minute, namespace, "http://localhost:8080")
 			Expect(err).NotTo(HaveOccurred())
 			_, err = reconciler.Reconcile(ctx, serviceId)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Add health timeout for all progressing resources. Previously it was only done for Ai Insight Component Scraper. Now it's global