### PR TITLE
feat: add configurable liveness and readiness probes to chart

### DIFF
--- a/charts/deployment-operator/templates/deployment.yaml
+++ b/charts/deployment-operator/templates/deployment.yaml
@@ -55,13 +55,9 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/deployment-operator/values.yaml
+++ b/charts/deployment-operator/values.yaml
@@ -7,6 +7,20 @@ additionalVolumeMounts: ~
 
 replicaCount: 1
 
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+    initialDelaySeconds: 10
+    timeout: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+    initialDelaySeconds: 10
+    timeout: 3
+
 args:
   processingTimeout: 5m
   enableHelmDependencyUpdate: false


### PR DESCRIPTION
Also, slightly extended default timeout and added initial delay before first checks will be executed.