### PR TITLE
chore: Split builds between ARM and AMD64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,6 @@ jobs:
             runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-        images: [ "ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator" ]
     runs-on: ${{ matrix.platforms.runner }}
     steps:
       - name: Checkout
@@ -73,7 +72,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ matrix.images }}
+          images: pluralsh/deployment-operator
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
           username: mjgpluralsh
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: "."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,12 +78,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -130,6 +124,12 @@ jobs:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,10 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.63.4
-  publish:
+  build-image:
     name: Build image
-#    needs:
-#      - test
+    needs:
+      - test
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -109,9 +109,10 @@ jobs:
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
-  merge:
+  publish-image:
+    name: Publish image
     needs:
-      - publish
+      - build-image
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,8 +92,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platforms.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
           build-args: |
             GIT_COMMIT=${{ github.sha }}
       - name: Export digest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,14 @@ jobs:
           version: v1.63.4
   publish:
     name: Build and push Agent container
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        platforms:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.platforms.runner }}
     needs:
     - test
     permissions:
@@ -93,7 +100,7 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platforms.platform }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,8 @@ jobs:
           version: v1.63.4
   publish:
     name: Build and push Agent container
-    needs:
-      - test
+#    needs:
+#      - test
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
   build-image:
     name: Build image
     needs:
+      - build
       - test
     permissions:
       contents: 'read'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,8 +92,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platforms.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             GIT_COMMIT=${{ github.sha }}
       - name: Export digest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         with:
           context: "."
           file: "./Dockerfile"
-          tags: ${{ matrix.images }}
+          tags: pluralsh/deployment-operator
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platforms.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,7 @@ jobs:
           version: v1.63.4
   build-image:
     name: Build image
-    needs:
-      - build
-      - test
+    needs: [build, test]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -112,8 +110,7 @@ jobs:
           retention-days: 1
   publish-image:
     name: Publish image
-    needs:
-      - build-image
+    needs: [build-image]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,64 +44,113 @@ jobs:
           version: v1.63.4
   publish:
     name: Build and push Agent container
+    needs:
+      - test
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      packages: 'write'
     strategy:
+      fail-fast: false
       matrix:
         platforms:
           - platform: linux/amd64
             runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+        images: ["ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator"]
     runs-on: ${{ matrix.platforms.runner }}
-    needs:
-    - test
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-      packages: 'write'
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        # list of Docker images to use as base name for tags
-        images: |
-          ghcr.io/pluralsh/deployment-operator
-          docker.io/pluralsh/deployment-operator
-        # generate Docker tags based on the following events/attributes
-        tags: |
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platforms.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.images }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: mjgpluralsh
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Build and push by digest
+        uses: docker/build-push-action@v6
+        with:
+          context: "."
+          file: "./Dockerfile"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platforms.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    needs:
+      - publish
+    strategy:
+      fail-fast: false
+      matrix:
+        images: [ "ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator" ]
+    runs-on: ${{ matrix.platforms.runner }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: mjgpluralsh
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.images }}
+          tags: |
             type=sha
             type=ref,event=pr
             type=ref,event=branch
             type=semver,pattern={{version}},value=${{ needs.prepare.outputs.new_release_version }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to GHCR
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Login to Docker
-      uses: docker/login-action@v3
-      with:
-        username: mjgpluralsh
-        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-    - name: Build and push
-      uses: docker/build-push-action@v5
-      with:
-        context: "."
-        file: "./Dockerfile"
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: ${{ matrix.platforms.platform }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: |
-          GIT_COMMIT=${{ github.sha }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.images }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ matrix.images }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
       fail-fast: false
       matrix:
         images: [ "ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator" ]
-    runs-on: ${{ matrix.platforms.runner }}
+    runs-on: ubuntu-latest
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
             runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+        images: [ "ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator" ]
     runs-on: ${{ matrix.platforms.runner }}
     steps:
       - name: Checkout
@@ -72,9 +73,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/pluralsh/deployment-operator
-            docker.io/pluralsh/deployment-operator
+          images: ${{ matrix.images }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -95,7 +94,7 @@ jobs:
         with:
           context: "."
           file: "./Dockerfile"
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ matrix.images }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platforms.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 env:
   GOPATH: /home/runner/go/
   GOPROXY: "https://proxy.golang.org"
+  REGISTRY_IMAGE: pluralsh/deployment-operator
 jobs:
   build:
     name: Build
@@ -43,7 +44,7 @@ jobs:
         with:
           version: v1.63.4
   publish:
-    name: Build and push Agent container
+    name: Build image
 #    needs:
 #      - test
     permissions:
@@ -72,7 +73,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: pluralsh/deployment-operator
+          images: ${{ env.REGISTRY_IMAGE }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -94,7 +95,7 @@ jobs:
         with:
           context: "."
           file: "./Dockerfile"
-          tags: pluralsh/deployment-operator
+          tags: ${{ env.REGISTRY_IMAGE }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platforms.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
@@ -150,7 +151,7 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ matrix.images }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ matrix.images }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,6 @@ jobs:
             runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-        images: ["ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator"]
     runs-on: ${{ matrix.platforms.runner }}
     steps:
       - name: Checkout
@@ -73,7 +72,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ matrix.images }}
+          images: |
+            ghcr.io/pluralsh/deployment-operator
+            docker.io/pluralsh/deployment-operator
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ on:
 env:
   GOPATH: /home/runner/go/
   GOPROXY: "https://proxy.golang.org"
-
+  REGISTRY_IMAGE: pluralsh/deployment-operator
 jobs:
   test:
     name: Unit test
@@ -20,30 +20,36 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - run: PATH=$PATH:$GOPATH/bin make test
-  publish-docker:
-    name: Build and push agent container
-    runs-on: ubuntu-20.04
+  build-image:
+    name: Build image
     needs: [test]
     permissions:
       contents: 'read'
       id-token: 'write'
       packages: 'write'
+    strategy:
+      fail-fast: false
+      matrix:
+        platforms:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.platforms.runner }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platforms.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
       with:
-        # list of Docker images to use as base name for tags
-        images: |
-          ghcr.io/pluralsh/deployment-operator
-          docker.io/pluralsh/deployment-operator
-        # generate Docker tags based on the following events/attributes
-        tags: |
-          type=semver,pattern={{version}}
+        images: ${{ env.REGISTRY_IMAGE }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -59,31 +65,86 @@ jobs:
       with:
         username: mjgpluralsh
         password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-    - name: Build and push
-      uses: docker/build-push-action@v5
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
       with:
         context: "."
         file: "./Dockerfile"
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
+        tags: ${{ env.REGISTRY_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platforms.platform }}
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |
           GIT_COMMIT=${{ github.sha }}
-    - name: slack webhook
-      uses: 8398a7/action-slack@v3
+    - name: Export digest
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
       with:
-        status: ${{ job.status }}
-        fields: workflow,job,repo,message,commit,author
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
-      if: always()
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+  publish-image:
+    name: Publish image
+    needs: [build-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        images: [ "ghcr.io/pluralsh/deployment-operator", "docker.io/pluralsh/deployment-operator" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: mjgpluralsh
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.images }}
+          tags: type=semver,pattern={{version}}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ matrix.images }}:${{ steps.meta.outputs.version }}
+      - name: slack webhook
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: workflow,job,repo,message,commit,author
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
+        if: always()
   bump:
     name: Bump Chart Version
-    runs-on: ubuntu-20.04
-    needs: [publish-docker]
+    runs-on: ubuntu-latest
+    needs: [publish-image]
     permissions:
       contents: write
       discussions: write


### PR DESCRIPTION
See: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

Results:
<img width="957" alt="Zrzut ekranu 2025-04-14 o 15 31 41" src="https://github.com/user-attachments/assets/e642b7e8-c5f0-4686-9347-3b4f25bcae9d" />
<img width="1003" alt="Zrzut ekranu 2025-04-14 o 15 20 34" src="https://github.com/user-attachments/assets/a3c1ea7e-9a2e-4597-bdf5-ed0dcfd34448" />
<img width="665" alt="Zrzut ekranu 2025-04-14 o 14 23 54" src="https://github.com/user-attachments/assets/0e095df3-0d91-4559-99bb-54e9960915f9" />
