### PR TITLE
perf: deployment improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           version: v1.63.4
   build-image:
     name: Build image
-    #needs: [build, test]
+    needs: [build, test]
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           version: v1.63.4
   build-image:
     name: Build image
-    needs: [build, test]
+    #needs: [build, test]
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/cmd/agent/kubernetes.go
+++ b/cmd/agent/kubernetes.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -36,6 +37,9 @@ const serviceIDCacheExpiry = 12 * time.Hour
 
 func initKubeManagerOrDie(config *rest.Config) manager.Manager {
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		NewClient: func(config *rest.Config, options ctrlclient.Options) (ctrlclient.Client, error) {
+			return ctrlclient.New(config, options) // completely bypass the cache
+		},
 		Logger:                 setupLog,
 		Scheme:                 scheme,
 		LeaderElection:         args.EnableLeaderElection(),

--- a/cmd/agent/kubernetes.go
+++ b/cmd/agent/kubernetes.go
@@ -37,7 +37,7 @@ const serviceIDCacheExpiry = 12 * time.Hour
 
 func initKubeManagerOrDie(config *rest.Config) manager.Manager {
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
-		NewClient:              ctrlclient.New,
+		NewClient:              ctrlclient.New, // client reads directly from the API server
 		Logger:                 setupLog,
 		Scheme:                 scheme,
 		LeaderElection:         args.EnableLeaderElection(),

--- a/cmd/agent/kubernetes.go
+++ b/cmd/agent/kubernetes.go
@@ -37,9 +37,7 @@ const serviceIDCacheExpiry = 12 * time.Hour
 
 func initKubeManagerOrDie(config *rest.Config) manager.Manager {
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
-		NewClient: func(config *rest.Config, options ctrlclient.Options) (ctrlclient.Client, error) {
-			return ctrlclient.New(config, options) // completely bypass the cache
-		},
+		NewClient:              ctrlclient.New,
 		Logger:                 setupLog,
 		Scheme:                 scheme,
 		LeaderElection:         args.EnableLeaderElection(),

--- a/pkg/common/status.go
+++ b/pkg/common/status.go
@@ -36,14 +36,11 @@ func init() {
 		ticker := time.NewTicker(cleanupAfter)
 		defer ticker.Stop()
 
-		for {
-			select {
-			case <-ticker.C:
-				cleanupTime := time.Now().Add(-cleanupAfter)
-				for k, v := range healthStatus.Items() {
-					if v.PingTime.Before(cleanupTime) {
-						healthStatus.Remove(k)
-					}
+		for range ticker.C {
+			cleanupTime := time.Now().Add(-cleanupAfter)
+			for k, v := range healthStatus.Items() {
+				if v.PingTime.Before(cleanupTime) {
+					healthStatus.Remove(k)
 				}
 			}
 		}

--- a/pkg/common/status.go
+++ b/pkg/common/status.go
@@ -1,16 +1,59 @@
 package common
 
 import (
+	"fmt"
+	"time"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
 	console "github.com/pluralsh/console/go/client"
+	internalschema "github.com/pluralsh/deployment-operator/internal/kubernetes/schema"
+	"github.com/pluralsh/polly/containers"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
-
-	internalschema "github.com/pluralsh/deployment-operator/internal/kubernetes/schema"
 )
+
+const (
+	cleanupAfter       = 3 * time.Minute
+	cutoffProgressTime = 1 * time.Minute
+)
+
+var healthStatus cmap.ConcurrentMap[string, Progress]
+
+var supportedProgressingKinds = containers.ToSet[schema.GroupVersionKind]([]schema.GroupVersionKind{
+	{Group: "apps", Version: "v1", Kind: "DaemonSet"},
+	{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+	{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+})
+
+func init() {
+	healthStatus = cmap.New[Progress]()
+
+	go func() {
+		ticker := time.NewTicker(cleanupAfter)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				cleanupTime := time.Now().Add(-cleanupAfter)
+				for k, v := range healthStatus.Items() {
+					if v.PingTime.Before(cleanupTime) {
+						healthStatus.Remove(k)
+					}
+				}
+			}
+		}
+	}()
+}
+
+type Progress struct {
+	LastProgress time.Time
+	PingTime     time.Time
+}
 
 func StatusEventToComponentAttributes(e event.StatusEvent, vcache map[internalschema.GroupName]string) *console.ComponentAttributes {
 	if e.Resource == nil {
@@ -73,6 +116,7 @@ func ToStatus(obj *unstructured.Unstructured) *console.ComponentState {
 // GetResourceHealth returns the health of a k8s resource
 func GetResourceHealth(obj *unstructured.Unstructured) (health *HealthStatus, err error) {
 	if obj.GetDeletionTimestamp() != nil {
+		healthStatus.Remove(convertObjectToString(obj))
 		return &HealthStatus{
 			Status:  HealthStatusProgressing,
 			Message: "Pending deletion",
@@ -87,8 +131,45 @@ func GetResourceHealth(obj *unstructured.Unstructured) (health *HealthStatus, er
 			}
 		}
 	}
-	return health, err
 
+	if health == nil {
+		health = &HealthStatus{
+			Status: HealthStatusUnknown,
+		}
+	}
+
+	if supportedProgressingKinds.Has(obj.GroupVersionKind()) {
+		currentTime := time.Now()
+		strObject := convertObjectToString(obj)
+		if health.Status != HealthStatusProgressing {
+			healthStatus.Remove(strObject)
+			return health, nil
+		}
+
+		progressTime, ok := healthStatus.Get(strObject)
+		if !ok {
+			progressTime = Progress{
+				LastProgress: currentTime,
+			}
+		}
+		progressTime.PingTime = currentTime
+		healthStatus.Set(strObject, progressTime)
+
+		// mark as failed if it exceeds a threshold
+		cutoffTime := time.Now().Add(-cutoffProgressTime)
+
+		if progressTime.LastProgress.Before(cutoffTime) {
+			health.Status = HealthStatusDegraded
+		}
+
+		return health, nil
+	}
+
+	return health, err
+}
+
+func convertObjectToString(obj *unstructured.Unstructured) string {
+	return fmt.Sprintf("%s/%s/%s", obj.GetNamespace(), obj.GetName(), obj.GetObjectKind().GroupVersionKind())
 }
 
 // GetHealthCheckFunc returns built-in health check function or nil if health check is not supported

--- a/pkg/common/status.go
+++ b/pkg/common/status.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	cleanupAfter       = 3 * time.Minute
-	cutoffProgressTime = 1 * time.Minute
+	cleanupAfter       = 3 * time.Hour
+	cutoffProgressTime = 10 * time.Minute
 )
 
 var healthStatus cmap.ConcurrentMap[string, Progress]

--- a/pkg/scraper/component_scraper.go
+++ b/pkg/scraper/component_scraper.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pluralsh/deployment-operator/internal/utils"
-
 	"github.com/cert-manager/cert-manager/pkg/apis/certmanager"
 	"github.com/pluralsh/deployment-operator/internal/helpers"
 	"github.com/pluralsh/deployment-operator/pkg/common"
@@ -162,26 +160,26 @@ func getResourceHealthStatus(ctx context.Context, k8sClient ctrclient.Client, ob
 		return nil, err
 	}
 
-	progressTime, err := common.GetLastProgressTimestamp(ctx, k8sClient, obj)
-	if err != nil {
-		return nil, err
-	}
-
-	// remove entry if no longer progressing
-	if health.Status != common.HealthStatusProgressing {
-		// cleanup progress timestamp
-		annotations := obj.GetAnnotations()
-		delete(annotations, common.LastProgressTimeAnnotation)
-		obj.SetAnnotations(annotations)
-		return health, utils.TryToUpdate(ctx, k8sClient, obj)
-	}
-
-	// mark as failed if it exceeds a threshold
-	cutoffTime := metav1.NewTime(time.Now().Add(-30 * time.Minute))
-
-	if progressTime.Before(&cutoffTime) {
-		health.Status = common.HealthStatusDegraded
-	}
+	//progressTime, err := common.GetLastProgressTimestamp(ctx, k8sClient, obj)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//
+	//// remove entry if no longer progressing
+	//if health.Status != common.HealthStatusProgressing {
+	//	// cleanup progress timestamp
+	//	annotations := obj.GetAnnotations()
+	//	delete(annotations, common.LastProgressTimeAnnotation)
+	//	obj.SetAnnotations(annotations)
+	//	return health, utils.TryToUpdate(ctx, k8sClient, obj)
+	//}
+	//
+	//// mark as failed if it exceeds a threshold
+	//cutoffTime := metav1.NewTime(time.Now().Add(-30 * time.Minute))
+	//
+	//if progressTime.Before(&cutoffTime) {
+	//	health.Status = common.HealthStatusDegraded
+	//}
 
 	return health, nil
 }

--- a/pkg/scraper/component_scraper.go
+++ b/pkg/scraper/component_scraper.go
@@ -138,7 +138,7 @@ func setUnhealthyComponents(ctx context.Context, k8sClient ctrclient.Client, gvk
 			return err
 		}
 		for _, item := range items {
-			health, err := getResourceHealthStatus(ctx, k8sClient, &item)
+			health, err := common.GetResourceHealth(&item)
 			if err != nil {
 				return err
 			}
@@ -152,36 +152,6 @@ func setUnhealthyComponents(ctx context.Context, k8sClient ctrclient.Client, gvk
 		}
 	}
 	return nil
-}
-
-func getResourceHealthStatus(ctx context.Context, k8sClient ctrclient.Client, obj *unstructured.Unstructured) (*common.HealthStatus, error) {
-	health, err := common.GetResourceHealth(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	//progressTime, err := common.GetLastProgressTimestamp(ctx, k8sClient, obj)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
-	//// remove entry if no longer progressing
-	//if health.Status != common.HealthStatusProgressing {
-	//	// cleanup progress timestamp
-	//	annotations := obj.GetAnnotations()
-	//	delete(annotations, common.LastProgressTimeAnnotation)
-	//	obj.SetAnnotations(annotations)
-	//	return health, utils.TryToUpdate(ctx, k8sClient, obj)
-	//}
-	//
-	//// mark as failed if it exceeds a threshold
-	//cutoffTime := metav1.NewTime(time.Now().Add(-30 * time.Minute))
-	//
-	//if progressTime.Before(&cutoffTime) {
-	//	health.Status = common.HealthStatusDegraded
-	//}
-
-	return health, nil
 }
 
 func listResources(ctx context.Context, k8sClient ctrclient.Client, gvk schema.GroupVersionKind) *algorithms.Pager[unstructured.Unstructured] {


### PR DESCRIPTION
- disable go client cache for the agent
- use a map to store the progress time for the health status