### PR TITLE
feat: return recommendations for each pod in the parent object

### DIFF
--- a/internal/controller/kubecostextractor_controller.go
+++ b/internal/controller/kubecostextractor_controller.go
@@ -595,7 +595,6 @@ func (r *KubecostExtractorReconciler) convertClusterRecommendationAttributes(ctx
 	resourceName := name
 	splitName := strings.Split(name, "/")
 	if len(splitName) == 2 {
-		name = splitName[1]         // pod name
 		resourceName = splitName[0] // parent resource
 	}
 


### PR DESCRIPTION
Add multi-aggregation capability to `getAllocation` to retrieve pod-level allocations across Deployments, StatefulSets, and DaemonSets. Use this enhancement to return recommendations
