### PR TITLE
feat: Extend manifest cache duration

### DIFF
--- a/cmd/agent/args/args.go
+++ b/cmd/agent/args/args.go
@@ -74,7 +74,7 @@ var (
 	argDisableResourceCache            = flag.Bool("disable-resource-cache", !helpers.GetPluralEnvBool(EnvResourceCacheEnabled, true), "Control whether resource cache should be enabled or not.")
 	argEnableKubecostProxy             = flag.Bool("enable-kubecost-proxy", false, "If set, will proxy a Kubecost API request through the K8s API server.")
 
-	argMaxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 25, "Maximum number of concurrent reconciles which can be run.")
+	argMaxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 50, "Maximum number of concurrent reconciles which can be run.")
 	argResyncSeconds           = flag.Int("resync-seconds", 300, "Resync duration in seconds.")
 
 	argClusterId         = flag.String("cluster-id", "", "The ID of the cluster being connected to.")

--- a/cmd/agent/args/args.go
+++ b/cmd/agent/args/args.go
@@ -44,8 +44,8 @@ const (
 	defaultResourceCacheTTL         = "1h"
 	defaultResourceCacheTTLDuration = time.Hour
 
-	defaultManifestCacheTTL         = "1h"
-	defaultManifestCacheTTLDuration = time.Hour
+	defaultManifestCacheTTL         = "3h"
+	defaultManifestCacheTTLDuration = 3 * time.Hour
 
 	defaultManifestCacheJitter         = "30m"
 	defaultManifestCacheJitterDuration = 30 * time.Minute
@@ -74,7 +74,7 @@ var (
 	argDisableResourceCache            = flag.Bool("disable-resource-cache", !helpers.GetPluralEnvBool(EnvResourceCacheEnabled, true), "Control whether resource cache should be enabled or not.")
 	argEnableKubecostProxy             = flag.Bool("enable-kubecost-proxy", false, "If set, will proxy a Kubecost API request through the K8s API server.")
 
-	argMaxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 50, "Maximum number of concurrent reconciles which can be run.")
+	argMaxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 25, "Maximum number of concurrent reconciles which can be run.")
 	argResyncSeconds           = flag.Int("resync-seconds", 300, "Resync duration in seconds.")
 
 	argClusterId         = flag.String("cluster-id", "", "The ID of the cluster being connected to.")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,7 @@ func (c *Controller) SetupWithManager(manager *Manager) {
 	c.RecoverPanic = manager.RecoverPanic
 	c.PollInterval = manager.PollInterval
 	c.PollJitter = manager.PollJitter
-	c.DeQueueJitter = 5 * time.Second
+	c.DeQueueJitter = time.Second
 	c.lastPollTime = time.Now()
 }
 

--- a/pkg/manifests/tarball.go
+++ b/pkg/manifests/tarball.go
@@ -12,7 +12,13 @@ import (
 )
 
 var (
-	client = &http.Client{Timeout: 15 * time.Second}
+	timeout = 60 * time.Second
+	client  = &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: timeout,
+		},
+	}
 )
 
 func getBody(url, token string) (string, error) {


### PR DESCRIPTION
Extends this to three hours to reduce the need for unnecessary downloads further