### PR TITLE
chore: bump polly to v0.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pluralsh/console/go/client v1.45.2
 	github.com/pluralsh/controller-reconcile-helper v0.1.0
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
-	github.com/pluralsh/polly v0.2.2
+	github.com/pluralsh/polly v0.2.3
 	github.com/prometheus/client_golang v1.21.1
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/samber/lo v1.50.0

--- a/go.sum
+++ b/go.sum
@@ -1808,8 +1808,8 @@ github.com/pluralsh/controller-reconcile-helper v0.1.0 h1:BV3dYZFH5rn8ZvZjtpkACS
 github.com/pluralsh/controller-reconcile-helper v0.1.0/go.mod h1:RxAbvSB4/jkvx616krCdNQXPbpGJXW3J1L3rASxeFOA=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34/go.mod h1:IagWXKFYu6NTHzcJx2dJyrIlZ1Sv2PH3fhOtplA9qOs=
-github.com/pluralsh/polly v0.2.2 h1:yYT82D6o9jr3/c/BmEAb/7YwqevxjWcW0FdN0ZiFTwc=
-github.com/pluralsh/polly v0.2.2/go.mod h1:7JbPHfug0GrBvt8odly5mo7a3mxdwLPheUzYc+Ld2IQ=
+github.com/pluralsh/polly v0.2.3 h1:94S61B2gkpK8fUCMl10n36xX6Fh2kf2rlRWLr5UWS1g=
+github.com/pluralsh/polly v0.2.3/go.mod h1:GpeJrbPW0XedsoTXYRPhS5mc6GqIYLocOaRRSsZGisQ=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
 - add support for `encoding.merge` in the Helm Lua script