### PR TITLE
fix: Drop aquasecurity groups

### DIFF
--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -1,0 +1,17 @@
+package common
+
+import "strings"
+
+func ParseAPIVersion(apiVersion string) (group, version string) {
+	parts := strings.Split(apiVersion, "/")
+	if len(parts) == 2 {
+		group = parts[0]
+		version = parts[1]
+	}
+
+	if len(parts) == 1 {
+		version = parts[0]
+	}
+
+	return
+}

--- a/pkg/scraper/servergroups.go
+++ b/pkg/scraper/servergroups.go
@@ -42,6 +42,10 @@ func RunServerGroupsScraperInBackgroundOrDie(ctx context.Context, config *rest.C
 			}
 
 			for _, resource := range l.APIResources {
+				if cache.GroupBlacklist.Has(resource.Group) {
+					continue
+				}
+
 				rk := cache.ResourceKey{
 					GroupKind: runtimeschema.GroupKind{
 						Group: resource.Group,


### PR DESCRIPTION
This is probably too resource intensive for its own good, dropping them for now