### PR TITLE
wip: add ability to ignore field in a resource by json path

### DIFF
--- a/pkg/controller/service/normalizing.go
+++ b/pkg/controller/service/normalizing.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/xeipuuv/gojsonpointer"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IgnoreJSONPaths(ctx context.Context, c client.Client, obj unstructured.Unstructured, ignorePaths []string) (unstructured.Unstructured, error) {
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(obj.GroupVersionKind())
+
+	key := types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+
+	if err := c.Get(ctx, key, current); err != nil {
+		if apierrors.IsNotFound(err) {
+			return obj, nil // Object doesn't exist, skip
+		}
+		return unstructured.Unstructured{}, fmt.Errorf("failed to get live object: %w", err)
+	}
+
+	// Compare and overwrite ignored paths
+	for _, path := range ignorePaths {
+		ptr, err := gojsonpointer.NewJsonPointer(path)
+		if err != nil {
+			return unstructured.Unstructured{}, fmt.Errorf("invalid JSON pointer %q: %w", path, err)
+		}
+
+		liveVal, _, err := ptr.Get(current.Object)
+		if err != nil {
+			continue // Ignore missing path
+		}
+
+		desiredVal, _, err := ptr.Get(obj.Object)
+		if err != nil || !reflect.DeepEqual(liveVal, desiredVal) {
+			// Set the desired object's field to the live value
+			_, err = ptr.Set(obj.Object, liveVal)
+			if err != nil {
+				return unstructured.Unstructured{}, fmt.Errorf("failed to set path %s: %w", path, err)
+			}
+		}
+	}
+
+	return obj, nil
+}
+
+type normalizerKey struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+func matchesKey(obj unstructured.Unstructured, key normalizerKey) bool {
+	if key.Kind != "" && obj.GetKind() != key.Kind {
+		return false
+	}
+	if key.Name != "" && obj.GetName() != key.Name {
+		return false
+	}
+	if key.Namespace != "" && obj.GetNamespace() != key.Namespace {
+		return false
+	}
+	return true
+}

--- a/pkg/controller/service/normalizing_test.go
+++ b/pkg/controller/service/normalizing_test.go
@@ -1,0 +1,94 @@
+package service_test
+
+import (
+	"context"
+
+	"github.com/pluralsh/deployment-operator/pkg/controller/service"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DiffNormalizers", Ordered, func() {
+	Context("IgnoreJSONPaths", func() {
+		const (
+			resourceName = "default-ignore-json-paths"
+			namespace    = "default"
+		)
+		desiredPodYAML := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: default-ignore-json-paths
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: nginx:latest
+`
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		var desiredPod corev1.Pod
+		Expect(yaml.Unmarshal([]byte(desiredPodYAML), &desiredPod)).To(Succeed())
+		desiredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&desiredPod)
+		Expect(err).ToNot(HaveOccurred())
+		desired := unstructured.Unstructured{Object: desiredObj}
+
+		livePod := &corev1.Pod{}
+
+		BeforeAll(func() {
+			By("creating the custom resource for the Kind Pod")
+			err := kClient.Get(ctx, typeNamespacedName, livePod)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: namespace,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "app",
+								Image: "nginx:1.25",
+							},
+						},
+					},
+				}
+				Expect(kClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterAll(func() {
+			resource := &corev1.Pod{}
+			err := kClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Pod")
+			Expect(kClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should skip update", func() {
+			ignorePaths := []string{"/spec/containers/0/image"}
+			desired, err := service.IgnoreJSONPaths(context.Background(), kClient, desired, ignorePaths)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedPod := &corev1.Pod{}
+			err = runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(desired.Object, expectedPod, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(expectedPod.Spec.Containers[0].Image).To(Equal("nginx:1.25"))
+
+		})
+	})
+})


### PR DESCRIPTION
This PR introduces the ignoreUpdateFields mechanism to support drift normalization by ignoring updates on specific subfields of the service's resources. 
 - Resources can define ignored fields via the `deployments.plural.sh/ignore-fields` annotation. The annotation accepts a comma-separated list of JSON paths (e.g. /spec/replicas,/metadata/labels).
 - Also supports ignoring fields via the `ServiceDeployment.Spec.SyncConfig.DiffNormalizers` field, providing more centralized configuration.

