### PR TITLE
feat: add additional cluster fields to ping requests

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"time"
 
-	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
-
 	kubernetestrace "github.com/DataDog/dd-trace-go/contrib/k8s.io/client-go/v2/kubernetes"
 	datadogtracer "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	datadogprofiler "github.com/DataDog/dd-trace-go/v2/profiler"
@@ -111,14 +109,8 @@ func main() {
 	// Start the discovery cache in background.
 	cache.RunDiscoveryCacheInBackgroundOrDie(ctx, discoveryClient)
 
-	metricsClient, err := metricsclientset.NewForConfig(config)
-	if err != nil {
-		setupLog.Error(err, "unable to create metrics client")
-		os.Exit(1)
-	}
-
 	// Start the metrics scarper in background.
-	scraper.RunMetricsScraperInBackgroundOrDie(ctx, kubeManager.GetClient(), discoveryClient, metricsClient)
+	scraper.RunMetricsScraperInBackgroundOrDie(ctx, kubeManager.GetClient(), discoveryClient, config)
 
 	// Start the console manager in background.
 	runConsoleManagerInBackgroundOrDie(ctx, consoleManager)

--- a/internal/controller/metricsaggregate_controller_test.go
+++ b/internal/controller/metricsaggregate_controller_test.go
@@ -128,7 +128,6 @@ var _ = Describe("MetricsAggregate Controller", Ordered, func() {
 				Client:          kClient,
 				Scheme:          kClient.Scheme(),
 				DiscoveryClient: discoveryClient,
-				MetricsClient:   metricsClient,
 			}
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: metricsAggregate})
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/metricsaggregate_controller_test.go
+++ b/internal/controller/metricsaggregate_controller_test.go
@@ -3,25 +3,20 @@ package controller
 import (
 	"context"
 
-	"github.com/pluralsh/deployment-operator/api/v1alpha1"
-	"github.com/pluralsh/deployment-operator/pkg/test/mocks"
-	"github.com/stretchr/testify/mock"
+	"github.com/pluralsh/deployment-operator/pkg/scraper"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
+	"github.com/pluralsh/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/deployment-operator/pkg/test/mocks"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("MetricsAggregate Controller", Ordered, func() {
 	Context("When reconciling a resource", func() {
 		const (
-			nodeName             = "node"
 			metricsAggregateName = "global"
 			namespace            = "default"
 		)
@@ -38,64 +33,7 @@ var _ = Describe("MetricsAggregate Controller", Ordered, func() {
 				},
 			},
 		}
-
-		nodeMetrics := types.NamespacedName{Name: nodeName, Namespace: namespace}
-		node := types.NamespacedName{Name: nodeName, Namespace: namespace}
 		metricsAggregate := types.NamespacedName{Name: metricsAggregateName, Namespace: namespace}
-
-		defaultNodeMetrics := v1beta1.NodeMetrics{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      nodeName,
-				Namespace: namespace,
-			},
-			Timestamp: metav1.Time{},
-			Window:    metav1.Duration{},
-			Usage: map[corev1.ResourceName]resource.Quantity{
-				"cpu":    resource.MustParse("100m"),
-				"memory": resource.MustParse("100Mi"),
-			},
-		}
-		defaultNodeMetricsList := &v1beta1.NodeMetricsList{
-			Items: []v1beta1.NodeMetrics{
-				defaultNodeMetrics,
-			},
-		}
-
-		nm := &v1beta1.NodeMetrics{}
-		n := &corev1.Node{}
-		BeforeAll(func() {
-			By("Creating node metrics")
-			err := kClient.Get(ctx, nodeMetrics, nm)
-			if err != nil && errors.IsNotFound(err) {
-				Expect(kClient.Create(ctx, &defaultNodeMetrics)).To(Succeed())
-			}
-
-			By("Creating Node")
-			err = kClient.Get(ctx, node, n)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      nodeName,
-						Namespace: namespace,
-					},
-					Spec: corev1.NodeSpec{},
-					Status: corev1.NodeStatus{
-						Capacity: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("1Gi"),
-						},
-					},
-				}
-				Expect(kClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterAll(func() {
-			By("Cleanup node")
-			n := &corev1.Node{}
-			Expect(kClient.Get(ctx, node, n)).NotTo(HaveOccurred())
-			Expect(kClient.Delete(ctx, n)).To(Succeed())
-		})
 
 		It("should create global metrics aggregate", func() {
 
@@ -114,15 +52,19 @@ var _ = Describe("MetricsAggregate Controller", Ordered, func() {
 		})
 
 		It("should create global metrics aggregate", func() {
-			metricsClient := mocks.NewInterfaceMock(mocks.TestingT)
-			metricsV1beta1 := mocks.NewMetricsV1beta1InterfaceMock(mocks.TestingT)
-			nodeMetricses := mocks.NewNodeMetricsInterfaceMock(mocks.TestingT)
-			metricsClient.On("MetricsV1beta1").Return(metricsV1beta1)
-			metricsV1beta1.On("NodeMetricses").Return(nodeMetricses)
-			nodeMetricses.On("List", mock.Anything, mock.Anything).Return(defaultNodeMetricsList, nil)
-
 			discoveryClient := mocks.NewDiscoveryInterfaceMock(mocks.TestingT)
 			discoveryClient.On("ServerGroups").Return(apiGroups, nil)
+
+			scraper.GetMetrics().Add(v1alpha1.MetricsAggregateStatus{
+				Nodes:                  1,
+				MemoryTotalBytes:       104857600,
+				MemoryAvailableBytes:   1073741824,
+				MemoryUsedPercentage:   10,
+				CPUTotalMillicores:     100,
+				CPUAvailableMillicores: 1000,
+				CPUUsedPercentage:      10,
+				Conditions:             nil,
+			})
 
 			r := MetricsAggregateReconciler{
 				Client:          kClient,
@@ -139,7 +81,7 @@ var _ = Describe("MetricsAggregate Controller", Ordered, func() {
 			Expect(metrics.Status.CPUUsedPercentage).Should(Equal(int64(10)))
 			Expect(metrics.Status.MemoryAvailableBytes).Should(Equal(int64(1073741824)))
 			Expect(metrics.Status.MemoryTotalBytes).Should(Equal(int64(104857600)))
-			Expect(metrics.Status.MemoryUsedPercentage).Should(Equal(int64(9)))
+			Expect(metrics.Status.MemoryUsedPercentage).Should(Equal(int64(10)))
 		})
 	})
 })

--- a/pkg/cache/db/cache.go
+++ b/pkg/cache/db/cache.go
@@ -243,6 +243,23 @@ func (in *ComponentCache) NodeStatistics() ([]*client.NodeStatisticAttributes, e
 	return result, err
 }
 
+func (in *ComponentCache) ComponentCounts() (nodeCount, namespaceCount int64, err error) {
+	conn, err := in.pool.Take(context.Background())
+	if err != nil {
+		return
+	}
+	defer in.pool.Put(conn)
+
+	err = sqlitex.ExecuteTransient(conn, serverCounts, &sqlitex.ExecOptions{
+		ResultFunc: func(stmt *sqlite.Stmt) error {
+			nodeCount = stmt.ColumnInt64(0)
+			namespaceCount = stmt.ColumnInt64(1)
+			return nil
+		},
+	})
+	return
+}
+
 func nodeHealth(pendingPods int64) *client.NodeStatisticHealth {
 	switch {
 	case pendingPods == 0:

--- a/pkg/cache/db/queries.go
+++ b/pkg/cache/db/queries.go
@@ -135,4 +135,9 @@ const (
 		   ) AND cc.kind IN ('Deployment', 'StatefulSet', 'Ingress', 'DaemonSet', 'Certificate')))
            AND cc.kind IN ('Deployment', 'StatefulSet', 'Ingress', 'DaemonSet', 'Certificate')
 	`
+	serverCounts = `
+	SELECT
+  		COUNT(DISTINCT CASE WHEN kind = 'Node' THEN uid END) AS node_count,
+  		COUNT(DISTINCT CASE WHEN kind = 'Namespace' THEN uid END) AS namespace_count
+	FROM component`
 )

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -1,6 +1,20 @@
 package common
 
-import "strings"
+import (
+	"context"
+	"fmt"
+
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+
+	"strings"
+
+	"github.com/pluralsh/deployment-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 func ParseAPIVersion(apiVersion string) (group, version string) {
 	parts := strings.Split(apiVersion, "/")
@@ -14,4 +28,117 @@ func ParseAPIVersion(apiVersion string) (group, version string) {
 	}
 
 	return
+}
+
+type ResourceMetricsInfo struct {
+	Name      string
+	Metrics   corev1.ResourceList
+	Available corev1.ResourceList
+}
+
+var supportedMetricsAPIVersions = []string{
+	"v1beta1",
+}
+
+func GetMetricsAggregateStatus(ctx context.Context, client k8sClient.Client, metricsClient metricsclientset.Interface) (*v1alpha1.MetricsAggregateStatus, error) {
+	status := &v1alpha1.MetricsAggregateStatus{}
+	nodeList := &corev1.NodeList{}
+	if err := client.List(ctx, nodeList); err != nil {
+		return nil, err
+	}
+
+	availableResources := make(map[string]corev1.ResourceList)
+	for _, n := range nodeList.Items {
+		// Total number, contains system reserved resources
+		availableResources[n.Name] = n.Status.Capacity
+	}
+
+	nodeDeploymentNodesMetrics := make([]v1beta1.NodeMetrics, 0)
+	allNodeMetricsList, err := metricsClient.MetricsV1beta1().NodeMetricses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range allNodeMetricsList.Items {
+		if _, ok := availableResources[m.Name]; ok {
+			nodeDeploymentNodesMetrics = append(nodeDeploymentNodesMetrics, m)
+		}
+	}
+
+	nodeMetrics, err := ConvertNodeMetrics(nodeDeploymentNodesMetrics, availableResources)
+	if err != nil {
+		return nil, err
+	}
+
+	// save metrics
+	status.Nodes = len(nodeList.Items)
+	var cpuAvailableMillicores, cpuTotalMillicores, memoryAvailableBytes, memoryTotalBytes int64
+	for _, nm := range nodeMetrics {
+		cpuAvailableMillicores += nm.CPUAvailableMillicores
+		cpuTotalMillicores += nm.CPUTotalMillicores
+		memoryAvailableBytes += nm.MemoryAvailableBytes
+		memoryTotalBytes += nm.MemoryTotalBytes
+	}
+	status.CPUAvailableMillicores = cpuAvailableMillicores
+	status.CPUTotalMillicores = cpuTotalMillicores
+	status.MemoryAvailableBytes = memoryAvailableBytes
+	status.MemoryTotalBytes = memoryTotalBytes
+
+	fraction := float64(status.CPUTotalMillicores) / float64(status.CPUAvailableMillicores) * 100
+	status.CPUUsedPercentage = int64(fraction)
+	fraction = float64(status.MemoryTotalBytes) / float64(status.MemoryAvailableBytes) * 100
+	status.MemoryUsedPercentage = int64(fraction)
+
+	return status, nil
+}
+
+func ConvertNodeMetrics(metrics []v1beta1.NodeMetrics, availableResources map[string]corev1.ResourceList) ([]v1alpha1.MetricsAggregateStatus, error) {
+	nodeMetrics := make([]v1alpha1.MetricsAggregateStatus, 0)
+
+	if metrics == nil {
+		return nil, fmt.Errorf("metric list can not be nil")
+	}
+
+	for _, m := range metrics {
+		nodeMetric := v1alpha1.MetricsAggregateStatus{}
+
+		resourceMetricsInfo := ResourceMetricsInfo{
+			Name:      m.Name,
+			Metrics:   m.Usage.DeepCopy(),
+			Available: availableResources[m.Name],
+		}
+
+		if available, found := resourceMetricsInfo.Available[corev1.ResourceCPU]; found {
+			quantityCPU := resourceMetricsInfo.Metrics[corev1.ResourceCPU]
+			// cpu in mili cores
+			nodeMetric.CPUTotalMillicores = quantityCPU.MilliValue()
+			nodeMetric.CPUAvailableMillicores = available.MilliValue()
+		}
+
+		if available, found := resourceMetricsInfo.Available[corev1.ResourceMemory]; found {
+			quantityM := resourceMetricsInfo.Metrics[corev1.ResourceMemory]
+			// memory in bytes
+			nodeMetric.MemoryTotalBytes = quantityM.Value()     // in Bytes
+			nodeMetric.MemoryAvailableBytes = available.Value() // in Bytes
+		}
+		nodeMetrics = append(nodeMetrics, nodeMetric)
+	}
+
+	return nodeMetrics, nil
+}
+
+func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupList) bool {
+	for _, discoveredAPIGroup := range discoveredAPIGroups.Groups {
+		if discoveredAPIGroup.Name != metricsapi.GroupName {
+			continue
+		}
+		for _, version := range discoveredAPIGroup.Versions {
+			for _, supportedVersion := range supportedMetricsAPIVersions {
+				if version.Version == supportedVersion {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/ping/build.go
+++ b/pkg/ping/build.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 
 	console "github.com/pluralsh/console/go/client"
+	"github.com/pluralsh/deployment-operator/pkg/cache/db"
+	"github.com/pluralsh/deployment-operator/pkg/scraper"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog/v2"
-
-	"github.com/pluralsh/deployment-operator/pkg/cache/db"
 )
 
-func pingAttributes(info *version.Info, pods []string, minKubeletVersion *string) console.ClusterPing {
+func pingAttributes(info *version.Info, pods []string, minKubeletVersion *string, podCount *int64) console.ClusterPing {
 	hs, err := db.GetComponentCache().HealthScore()
 	if err != nil {
 		klog.ErrorS(err, "failed to get health score")
@@ -22,12 +22,23 @@ func pingAttributes(info *version.Info, pods []string, minKubeletVersion *string
 		klog.ErrorS(err, "failed to get node statistics")
 	}
 
+	nodCount, namespaceCount, err := db.GetComponentCache().ComponentCounts()
+	if err != nil {
+		klog.ErrorS(err, "failed to get cluster component counts")
+	}
+
 	vs := strings.Split(info.GitVersion, "-")
+
+	metrics := scraper.GetMetrics().Get()
+
 	cp := console.ClusterPing{
 		CurrentVersion: strings.TrimPrefix(vs[0], "v"),
-		Distro:         lo.ToPtr(findDistro(append(pods, info.GitVersion))),
 		KubeletVersion: minKubeletVersion,
+		Distro:         lo.ToPtr(findDistro(append(pods, info.GitVersion))),
 		HealthScore:    &hs,
+		NodeCount:      &nodCount,
+		PodCount:       podCount,
+		NamespaceCount: &namespaceCount,
 		NodeStatistics: ns,
 	}
 
@@ -37,6 +48,18 @@ func pingAttributes(info *version.Info, pods []string, minKubeletVersion *string
 	}
 
 	cp.InsightComponents = lo.ToSlicePtr(cInsights)
+	if metrics.CPUTotalMillicores > 0 {
+		cp.CPUTotal = lo.ToPtr(float64(metrics.CPUTotalMillicores))
+	}
+	if metrics.MemoryTotalBytes > 0 {
+		cp.MemoryTotal = lo.ToPtr(float64(metrics.MemoryTotalBytes))
+	}
+	if metrics.CPUUsedPercentage > 0 {
+		cp.CPUUtil = lo.ToPtr(float64(metrics.CPUUsedPercentage))
+	}
+	if metrics.MemoryUsedPercentage > 0 {
+		cp.MemoryUtil = lo.ToPtr(float64(metrics.MemoryUsedPercentage))
+	}
 
 	return cp
 }

--- a/pkg/scraper/metrics.go
+++ b/pkg/scraper/metrics.go
@@ -1,0 +1,72 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pluralsh/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/deployment-operator/internal/helpers"
+	"github.com/pluralsh/deployment-operator/pkg/common"
+	"k8s.io/client-go/discovery"
+	"k8s.io/klog/v2"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const name = "metrics scraper"
+
+var (
+	metrics *Metrics
+)
+
+func init() {
+	metrics = &Metrics{
+		metrics: v1alpha1.MetricsAggregateStatus{},
+	}
+}
+
+type Metrics struct {
+	mu      sync.RWMutex
+	metrics v1alpha1.MetricsAggregateStatus
+}
+
+func GetMetrics() *Metrics {
+	return metrics
+}
+
+func (s *Metrics) Add(metrics v1alpha1.MetricsAggregateStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metrics = metrics
+}
+
+func (s *Metrics) Get() v1alpha1.MetricsAggregateStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.metrics
+}
+
+func RunMetricsScraperInBackgroundOrDie(ctx context.Context, k8sClient ctrclient.Client, discoveryClient *discovery.DiscoveryClient, metricsClient metricsclientset.Interface) {
+	klog.Info("starting ", name)
+
+	err := helpers.BackgroundPollUntilContextCancel(ctx, time.Minute, true, true, func(_ context.Context) (done bool, err error) {
+		apiGroups, err := discoveryClient.ServerGroups()
+		if err == nil {
+			metricsAPIAvailable := common.SupportedMetricsAPIVersionAvailable(apiGroups)
+			if metricsAPIAvailable {
+				status, err := common.GetMetricsAggregateStatus(ctx, k8sClient, metricsClient)
+				if err == nil && status != nil {
+					GetMetrics().Add(*status)
+				} else if err != nil {
+					klog.Error(err, "failed to get metrics")
+				}
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to start %s in background: %w", name, err))
+	}
+}

--- a/pkg/scraper/metrics.go
+++ b/pkg/scraper/metrics.go
@@ -62,14 +62,13 @@ func RunMetricsScraperInBackgroundOrDie(ctx context.Context, k8sClient ctrclient
 		apiGroups, err := discoveryClient.ServerGroups()
 		if err == nil {
 			metricsAPIAvailable := common.SupportedMetricsAPIVersionAvailable(apiGroups)
-			if metricsAPIAvailable {
-				status, err := common.GetMetricsAggregateStatus(ctx, k8sClient, metricsClient)
-				if err == nil && status != nil {
-					GetMetrics().Add(*status)
-				} else if err != nil {
-					klog.Error(err, "failed to get metrics")
-				}
+			status, err := common.GetMetricsAggregateStatus(ctx, k8sClient, metricsClient, metricsAPIAvailable)
+			if err == nil && status != nil {
+				GetMetrics().Add(*status)
+			} else if err != nil {
+				klog.Error(err, "failed to get metrics")
 			}
+
 		}
 		return false, nil
 	})

--- a/pkg/scraper/metrics.go
+++ b/pkg/scraper/metrics.go
@@ -68,7 +68,6 @@ func RunMetricsScraperInBackgroundOrDie(ctx context.Context, k8sClient ctrclient
 			} else if err != nil {
 				klog.Error(err, "failed to get metrics")
 			}
-
 		}
 		return false, nil
 	})


### PR DESCRIPTION
- Refactored metrics collection logic:
Moved the logic for fetching metrics from the MetricsAggregateReconciler to the scraper package.

 - Improved accessibility of metrics:
Metrics are now accessible to both the Pinger and MetricsAggregate controllers.

 - Extended ping request payloads:
Added additional cluster-related fields to ping.