### PR TITLE
fix: Work on dynamic poller fixes

### DIFF
--- a/pkg/controller/restore/reconciler.go
+++ b/pkg/controller/restore/reconciler.go
@@ -89,7 +89,7 @@ func (s *RestoreReconciler) Shutdown() {
 }
 
 func (s *RestoreReconciler) GetPollInterval() func() time.Duration {
-	return func() time.Duration { return s.pollInterval } // use default poll interval
+	return func() time.Duration { return time.Duration(0) } // use default poll interval
 }
 
 func (s *RestoreReconciler) GetPublisher() (string, websocket.Publisher) {

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -144,7 +144,6 @@ func (s *ServiceReconciler) GetPollInterval() func() time.Duration {
 		if servicePollInterval := agentcommon.GetConfigurationManager().GetServicePollInterval(); servicePollInterval != nil {
 			return *servicePollInterval
 		}
-
 		return s.pollInterval
 	}
 }


### PR DESCRIPTION
This apparently is still broken, the lastReconcileTime wasn't being initialized to a valid value (time.Now) and so since the new pollers slow-start, it would fail consistently.  Apparently only service reconcilers utilize the lastReconcile time, so only affected them.

Also adds a lot of logging - mostly was needed to figure out the root cause.

Fixes: PROD-3922

## Test Plan
e2e
Test environment: https://console.plrldemo.onplural.sh


## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have deployed the agent to a test environment and verified that it works as expected.
    - [x] Agent started successfully.
    - [x] Logs are clean and do not contain errors.
    - [x] Component trees are working as expected.
- [x] I have added tests to cover my changes.
- [x] If required, I have updated the Plural documentation accordingly.

