### PR TITLE
fix: cilium compatibilities not discovered

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog/v2"
 
 	internalerrors "github.com/pluralsh/deployment-operator/internal/errors"
+	"github.com/pluralsh/deployment-operator/pkg/log"
 )
 
 const (
@@ -111,7 +112,7 @@ func (c *client) RegisterRuntimeServices(svcs map[string]NamespaceVersion, depre
 	layouts = initServiceMesh(layouts, serviceMesh)
 	response, err := c.consoleClient.RegisterRuntimeServices(c.ctx, inputsPointers, layouts, lo.ToSlicePtr(deprecated), serviceId)
 	if response != nil {
-		klog.InfoS("registered runtime services", "count", lo.FromPtr(response.RegisterRuntimeServices))
+		klog.V(log.LogLevelVerbose).InfoS("registered runtime services", "count", lo.FromPtr(response.RegisterRuntimeServices))
 	}
 
 	return err

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -6,6 +6,7 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 
 	internalerrors "github.com/pluralsh/deployment-operator/internal/errors"
 )
@@ -16,11 +17,12 @@ const (
 	externalDNSServiceName  = "external-dns"
 	linkerdServiceName      = "Linkerd"
 	istioServiceName        = "istio"
-	ciliumServiceName       = "cilium"
+	CiliumServiceName       = "cilium"
 )
 
 var mapRuntimeService = map[string]string{
-	"istiod": istioServiceName,
+	"istiod":          istioServiceName,
+	"cilium-operator": CiliumServiceName,
 }
 
 func (c *client) PingCluster(attributes console.ClusterPing) error {
@@ -99,7 +101,7 @@ func (c *client) RegisterRuntimeServices(svcs map[string]NamespaceVersion, depre
 			case istioServiceName:
 				layouts = initLayouts(layouts)
 				layouts.Namespaces.Istio = &nv.Namespace
-			case ciliumServiceName:
+			case CiliumServiceName:
 				layouts = initLayouts(layouts)
 				layouts.Namespaces.Cilium = &nv.Namespace
 			}
@@ -107,7 +109,11 @@ func (c *client) RegisterRuntimeServices(svcs map[string]NamespaceVersion, depre
 	}
 	inputsPointers := lo.ToSlicePtr(inputs)
 	layouts = initServiceMesh(layouts, serviceMesh)
-	_, err := c.consoleClient.RegisterRuntimeServices(c.ctx, inputsPointers, layouts, lo.ToSlicePtr(deprecated), serviceId)
+	response, err := c.consoleClient.RegisterRuntimeServices(c.ctx, inputsPointers, layouts, lo.ToSlicePtr(deprecated), serviceId)
+	if response != nil {
+		klog.InfoS("registered runtime services", "count", lo.FromPtr(response.RegisterRuntimeServices))
+	}
+
 	return err
 }
 

--- a/pkg/ping/pinger.go
+++ b/pkg/ping/pinger.go
@@ -3,15 +3,17 @@ package ping
 import (
 	"fmt"
 
-	"github.com/pluralsh/deployment-operator/internal/utils"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/pluralsh/deployment-operator/pkg/client"
+	"github.com/pluralsh/deployment-operator/internal/utils"
+
 	"k8s.io/client-go/discovery"
 	"k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/pluralsh/deployment-operator/pkg/client"
 )
 
 type Pinger struct {

--- a/pkg/ping/runtime_service.go
+++ b/pkg/ping/runtime_service.go
@@ -193,38 +193,6 @@ func AddRuntimeServiceInfo(namespace string, labels map[string]string, acc map[s
 			return
 		}
 	}
-
-	//name := labels["app.kubernetes.io/name"]
-	//partOf := labels["app.kubernetes.io/part-of"]
-	//
-	//if len(vsn) == 0 {
-	//	return false
-	//}
-
-	//vsn, ok := labels["app.kubernetes.io/version"]
-	//if !ok {
-	//	return false
-	//}
-	//
-	//if name, ok := labels["app.kubernetes.io/name"]; ok {
-	//	acc[name] = addVersion(acc[name], vsn)
-	//	entry := acc[name]
-	//	entry.Namespace = namespace
-	//	if partOf, ok := labels["app.kubernetes.io/part-of"]; ok {
-	//		entry.PartOf = partOf
-	//	}
-	//	acc[name] = entry
-	//	return true
-	//}
-	//
-	//if name, ok := labels["app.kubernetes.io/part-of"]; ok {
-	//	acc[name] = addVersion(acc[name], vsn)
-	//	entry := acc[name]
-	//	entry.Namespace = namespace
-	//	acc[name] = entry
-	//}
-	//
-	//return true
 }
 
 func addServiceEntry(serviceName, version, namespace, partOfName string, acc map[string]client.NamespaceVersion) {


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Added runtime service mapping for cilium-operator to use its' version as the main cilium addon version
- Added heuristic search for version based on pod spec image name for cilium since their chart does not use well-known kubernetes version label
- Slightly refactored logic to be easier to understand

## Test Plan
<!-- Please provide a link to a test environment where you have deployed and tested the agent. -->
Test environment: https://console.plrl-dev-aws.onplural.sh

<!-- Please describe the tests you have added and preformed. -->

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have deployed the agent to a test environment and verified that it works as expected.
    - [x] Agent started successfully.
    - [x] Logs are clean and do not contain errors.
    - [x] Component trees are working as expected.
- [x] I have added tests to cover my changes.
- [x] If required, I have updated the Plural documentation accordingly.

