### PR TITLE
replace manual timers in poller with apimachinery wait utilities

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -141,7 +141,8 @@ func (s *ServiceReconciler) Shutdown() {
 
 func (s *ServiceReconciler) GetPollInterval() func() time.Duration {
 	return func() time.Duration {
-		if servicePollInterval := agentcommon.GetConfigurationManager().GetServicePollInterval(); servicePollInterval != nil {
+		// poll-interval cannot be lower than 10s
+		if servicePollInterval := agentcommon.GetConfigurationManager().GetServicePollInterval(); servicePollInterval != nil && *servicePollInterval >= 10*time.Second {
 			return *servicePollInterval
 		}
 		return s.pollInterval


### PR DESCRIPTION
Every call to `time.After` or `time.NewTimer` allocates a timer and an associated internal goroutine. In multiple threads or loops, these goroutines can accumulate if timers aren’t stopped properly. 
 - The k8s `wait` package avoids this by reusing timers and not leaking goroutines when polling.
 - The k8s `wait` functions integrate `runtime.HandleCrashWithContext`, which ensures that panics in callbacks don’t bring down the whole program.

## Test Plan
<!-- Please provide a link to a test environment where you have deployed and tested the agent. -->
Test environment: https://console.your-env.onplural.sh/

<!-- Please describe the tests you have added and preformed. -->

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have deployed the agent to a test environment and verified that it works as expected.
    - [ ] Agent started successfully.
    - [ ] Logs are clean and do not contain errors.
    - [ ] Component trees are working as expected.
- [ ] I have added tests to cover my changes.
- [ ] If required, I have updated the Plural documentation accordingly.

