### PR TITLE
fix: Bump go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/openshift/api v0.0.0-20250908150922-8634aa495a26
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
-	github.com/pluralsh/console/go/client v1.51.0
+	github.com/pluralsh/console/go/client v1.51.2
 	github.com/pluralsh/controller-reconcile-helper v0.1.0
 	github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34
 	github.com/pluralsh/polly v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -846,6 +846,10 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgm
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pluralsh/console/go/client v1.51.0 h1:rjRQDyKxixPf37lFQaA4RviDsJFBmyFNsDnwUYAb3E8=
 github.com/pluralsh/console/go/client v1.51.0/go.mod h1:EwMrcI23s61oLY3etCVc3NE5RYxgfoiokvU0O7KDOQg=
+github.com/pluralsh/console/go/client v1.51.1 h1:4X9J15FHF1Ohz+9cJA2GchzWk/1XTLwUMfmWOUWktzA=
+github.com/pluralsh/console/go/client v1.51.1/go.mod h1:EwMrcI23s61oLY3etCVc3NE5RYxgfoiokvU0O7KDOQg=
+github.com/pluralsh/console/go/client v1.51.2 h1:otRkECTnzahJwnuUqsYaS7yXE4ZlPndJd46Cqf6TbJs=
+github.com/pluralsh/console/go/client v1.51.2/go.mod h1:EwMrcI23s61oLY3etCVc3NE5RYxgfoiokvU0O7KDOQg=
 github.com/pluralsh/controller-reconcile-helper v0.1.0 h1:BV3dYZFH5rn8ZvZjtpkACSv/GmLEtRftNQj/Y4ddHEo=
 github.com/pluralsh/controller-reconcile-helper v0.1.0/go.mod h1:RxAbvSB4/jkvx616krCdNQXPbpGJXW3J1L3rASxeFOA=
 github.com/pluralsh/gophoenix v0.1.3-0.20231201014135-dff1b4309e34 h1:ab2PN+6if/Aq3/sJM0AVdy1SYuMAnq4g20VaKhTm/Bw=


### PR DESCRIPTION
Has a more performant way of sending document ids

## Test Plan
e2e

Test environment: https://console.plrldemo.onplural.sh/cd/clusters/fa83f9fd-4dcd-4778-94d1-0bde35cae95d/services/36ed839e-8d93-429c-b1b2-69519af81bb2/components/4c826cfb-1389-432f-89aa-adb639384ea3/info

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have deployed the agent to a test environment and verified that it works as expected.
    - [x] Agent starts successfully.
    - [x] Service creation works without any issues when using raw manifests and Helm templates.
    - [x] Service creation works when resources contain both CRD and CRD instances.
    - [x] Service templating works correctly.
    - [x] Service errors are reported properly and visible in the UI.
    - [x] Service updates are reflected properly in the cluster.
    - [x] Service resync triggers immediately and works as expected.
    - [x] Service deletion works and cleanups resources properly.
    - [x] Services can be recreated after deletion.
    - [x] Service detachment works and keeps resources unaffected.
    - [x] Services can be recreated after detachment.
    - [x] Service component trees are working as expected.
    - [x] Cluster health statuses are being updated.
    - [x] Agent logs do not contain any errors.
- [x] I have added tests to cover my changes.
- [x] If required, I have updated the Plural documentation accordingly.

