### PR TITLE
fix: Combining lua folder and string should have line breaks

### DIFF
--- a/pkg/manifests/template/helm.go
+++ b/pkg/manifests/template/helm.go
@@ -236,7 +236,7 @@ func (h *helm) luaValues(svc *console.ServiceDeploymentForAgent) (map[string]int
 		if err != nil {
 			return nil, valuesFiles, err
 		}
-		luaString = luaFolder + luaString
+		luaString = luaFolder + "\n\n" + luaString
 	}
 
 	if luaString == "" {


### PR DESCRIPTION
Causes syntax errors if last file doesn't end in newline

## Test Plan
<!-- Please provide a link to a test environment where you have deployed and tested the agent. -->
Test environment: https://console.plrldemo.onplural.sh/cd/clusters/31c95d8f-983c-435a-8985-bd1327f4334a/services/5486a614-6793-474d-92d6-4a338d10eace/components

<!-- Please describe the tests you have added and preformed. -->

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have deployed the agent to a test environment and verified that it works as expected.
    - [x] Agent starts successfully.
    - [x] Service creation works without any issues when using raw manifests and Helm templates.
    - [x] Service creation works when resources contain both CRD and CRD instances.
    - [x] Service templating works correctly.
    - [x] Service errors are reported properly and visible in the UI.
    - [x] Service updates are reflected properly in the cluster.
    - [x] Service resync triggers immediately and works as expected.
    - [x] Sync waves annotations are respected.
    - [x] Sync phases annotations are respected. Phases are executed in the correct order.
    - [x] Sync hook delete policies are respected. Resources are not recreated once they reach the desired state.
    - [x] Service deletion works and cleanups resources properly.
    - [x] Services can be recreated after deletion.
    - [x] Service detachment works and keeps resources unaffected.
    - [x] Services can be recreated after detachment.
    - [x] Service component trees are working as expected.
    - [x] Cluster health statuses are being updated.
    - [x] Agent logs do not contain any errors (after running for at least 30 minutes).
    - [x] There are no visible anomalies in Datadog (after running for at least 30 minutes).
- [x] I have added tests to cover my changes.
- [x] If required, I have updated the Plural documentation accordingly.

