### PR TITLE
fix: pass GIT_ASKPASS and GIT_TERMINAL_PROMPT=0 in the MCP server env

### DIFF
--- a/pkg/agentrun-harness/tool/codex/codex.go
+++ b/pkg/agentrun-harness/tool/codex/codex.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	consoleTokenEnv   = "PLRL_CONSOLE_TOKEN"
-	gitAccessTokenEnv = "GIT_ACCESS_TOKEN"
-	gitSigningKeyPath = common.GitSigningKeyMountPath
+	consoleTokenEnv    = "PLRL_CONSOLE_TOKEN"
+	gitAccessTokenEnv  = "GIT_ACCESS_TOKEN"
+	gitAskpassPath     = "/plural/.git-askpass"
+	gitSigningKeyPath  = common.GitSigningKeyMountPath
 )
 
 func New(config v1.Config) v1.Tool {
@@ -102,6 +103,15 @@ func (in *Codex) Configure(consoleURL, consoleToken, deployToken string) error {
 		}}
 	}
 
+	mcpBaseEnv := map[string]string{
+		consoleTokenEnv:        consoleToken,
+		"PLRL_CONSOLE_URL":     consoleURL,
+		"PLRL_AGENT_RUN_ID":    in.Config.Run.ID,
+		gitAccessTokenEnv:      os.Getenv(gitAccessTokenEnv),
+		"GIT_ASKPASS":          gitAskpassPath,
+		"GIT_TERMINAL_PROMPT":  "0",
+	}
+
 	switch in.Config.Run.Mode {
 	case console.AgentRunModeAnalyze:
 		agents = []AgentInput{{
@@ -119,11 +129,7 @@ func (in *Codex) Configure(consoleURL, consoleToken, deployToken string) error {
 			Command:      "/usr/local/bin/mcpserver",
 			TrustPolicy:  "always",
 			EnabledTools: []string{"updateAgentRunAnalysis"},
-			Env: map[string]string{
-				consoleTokenEnv:     consoleToken,
-				"PLRL_CONSOLE_URL":  consoleURL,
-				"PLRL_AGENT_RUN_ID": in.Config.Run.ID,
-			},
+			Env:          mcpBaseEnv,
 		}}
 	case console.AgentRunModeWrite:
 		agents = []AgentInput{{
@@ -141,11 +147,7 @@ func (in *Codex) Configure(consoleURL, consoleToken, deployToken string) error {
 			Command:      "/usr/local/bin/mcpserver",
 			TrustPolicy:  "always",
 			EnabledTools: []string{"agentPullRequest", "createBranch", "fetchAgentRunTodos", "updateAgentRunTodos"},
-			Env: map[string]string{
-				consoleTokenEnv:     consoleToken,
-				"PLRL_CONSOLE_URL":  consoleURL,
-				"PLRL_AGENT_RUN_ID": in.Config.Run.ID,
-			},
+			Env:          mcpBaseEnv,
 		}}
 	default:
 		return fmt.Errorf("unsupported agent run mode %q for codex", in.Config.Run.Mode)

--- a/pkg/agentrun-harness/tool/codex/codex.go
+++ b/pkg/agentrun-harness/tool/codex/codex.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	consoleTokenEnv    = "PLRL_CONSOLE_TOKEN"
-	gitAccessTokenEnv  = "GIT_ACCESS_TOKEN"
-	gitAskpassPath     = "/plural/.git-askpass"
-	gitSigningKeyPath  = common.GitSigningKeyMountPath
+	consoleTokenEnv   = "PLRL_CONSOLE_TOKEN"
+	gitAccessTokenEnv = "GIT_ACCESS_TOKEN"
+	gitAskpassPath    = "/plural/.git-askpass"
+	gitSigningKeyPath = common.GitSigningKeyMountPath
 )
 
 func New(config v1.Config) v1.Tool {
@@ -104,12 +104,12 @@ func (in *Codex) Configure(consoleURL, consoleToken, deployToken string) error {
 	}
 
 	mcpBaseEnv := map[string]string{
-		consoleTokenEnv:        consoleToken,
-		"PLRL_CONSOLE_URL":     consoleURL,
-		"PLRL_AGENT_RUN_ID":    in.Config.Run.ID,
-		gitAccessTokenEnv:      os.Getenv(gitAccessTokenEnv),
-		"GIT_ASKPASS":          gitAskpassPath,
-		"GIT_TERMINAL_PROMPT":  "0",
+		consoleTokenEnv:       consoleToken,
+		"PLRL_CONSOLE_URL":    consoleURL,
+		"PLRL_AGENT_RUN_ID":   in.Config.Run.ID,
+		gitAccessTokenEnv:     os.Getenv(gitAccessTokenEnv),
+		"GIT_ASKPASS":         gitAskpassPath,
+		"GIT_TERMINAL_PROMPT": "0",
 	}
 
 	switch in.Config.Run.Mode {


### PR DESCRIPTION
GIT_ASKPASS=/plural/.git-askpass explicitly tells git which askpass script to use.


## Test Plan
<!-- Please provide a link to a test environment where you have deployed and tested the agent. -->
Test environment: https://console.your-env.onplural.sh/

<!-- Please describe the tests you have added and preformed. -->

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have deployed the agent to a test environment and verified that it works as expected.
    - [ ] Agent starts successfully.
    - [ ] Service creation works without any issues when using raw manifests and Helm templates.
    - [ ] Service creation works when resources contain both CRD and CRD instances.
    - [ ] Service templating works correctly.
    - [ ] Service errors are reported properly and visible in the UI.
    - [ ] Service updates are reflected properly in the cluster.
    - [ ] Service resync triggers immediately and works as expected.
    - [ ] Sync waves annotations are respected.
    - [ ] Sync phases annotations are respected. Phases are executed in the correct order.
    - [ ] Sync hook delete policies are respected. Resources are not recreated once they reach the desired state.
    - [ ] Service deletion works and cleanups resources properly.
    - [ ] Services can be recreated after deletion.
    - [ ] Service detachment works and keeps resources unaffected.
    - [ ] Services can be recreated after detachment.
    - [ ] Service component trees are working as expected.
    - [ ] Cluster health statuses are being updated.
    - [ ] Agent logs do not contain any errors (after running for at least 30 minutes).
    - [ ] There are no visible anomalies in Datadog (after running for at least 30 minutes).
- [ ] I have added tests to cover my changes.
- [ ] If required, I have updated the Plural documentation accordingly.

