### PR TITLE
fix: sentinel cap1 bugs

### DIFF
--- a/pkg/sentinel-harness/controller/controller.go
+++ b/pkg/sentinel-harness/controller/controller.go
@@ -182,10 +182,7 @@ func buildGotestsumRunArgs(outputDir, junitPath, timeout string, integrationTest
 			}
 		}
 	}
-	disablesDefaultIntegrationTestCases := false
-	if integrationTestConfig != nil && integrationTestConfig.Default != nil && integrationTestConfig.Default.Ignore != nil && lo.FromPtr(integrationTestConfig.Default.Ignore) {
-		disablesDefaultIntegrationTestCases = true
-	}
+	disablesDefaultIntegrationTestCases := integrationTestConfig != nil && integrationTestConfig.Default != nil && integrationTestConfig.Default.Ignore != nil && lo.FromPtr(integrationTestConfig.Default.Ignore)
 
 	goTestArgs = append(goTestArgs, "--test.count", "1")
 	args = append(args, "--")

--- a/pkg/sentinel-harness/controller/controller.go
+++ b/pkg/sentinel-harness/controller/controller.go
@@ -182,10 +182,16 @@ func buildGotestsumRunArgs(outputDir, junitPath, timeout string, integrationTest
 			}
 		}
 	}
+	disablesDefaultIntegrationTestCases := false
+	if integrationTestConfig != nil && integrationTestConfig.Default != nil && integrationTestConfig.Default.Ignore != nil && lo.FromPtr(integrationTestConfig.Default.Ignore) {
+		disablesDefaultIntegrationTestCases = true
+	}
 
 	goTestArgs = append(goTestArgs, "--test.count", "1")
 	args = append(args, "--")
-	args = append(args, "./terratest/...")
+	if !disablesDefaultIntegrationTestCases {
+		args = append(args, "./terratest/...")
+	}
 	if useUserTests {
 		args = append(args, "./user-tests/...")
 	}

--- a/pkg/sentinel-harness/controller/controller.go
+++ b/pkg/sentinel-harness/controller/controller.go
@@ -123,21 +123,19 @@ func (in *sentinelRunController) runTests(fragment *console.SentinelRunJobFragme
 	args = buildGotestsumRunArgs(in.outputDir, junitPath, in.timeoutDuration, integrationTestConfig, userTests)
 	klog.V(log.LogLevelDefault).InfoS("running gotestsum", "args", args)
 
-	passed := false
-	err = cmd.Run("", args)
-	if err == nil {
-		passed = true
+	if err := cmd.Run("", args); err != nil {
+		klog.Warning("gotestsum returned an error", err)
 	}
 
-	output, err := DecodeTestJSONFileToString(filepath.Join(in.outputDir, jsonFile))
+	output, passed, err := DecodeTestJSONFileToString(filepath.Join(in.outputDir, jsonFile))
 	if err != nil {
-		return "", passed, err
+		return "", false, err
 	}
 
 	if in.outputFormat == junitFormat {
 		out, err := os.ReadFile(junitPath)
 		if err != nil {
-			return "", passed, err
+			return "", false, err
 		}
 		output = string(out)
 	}
@@ -283,10 +281,10 @@ type TestEvent struct {
 	Package string  `json:"Package,omitempty"`
 }
 
-func DecodeTestJSONFileToString(fileName string) (string, error) {
+func DecodeTestJSONFileToString(fileName string) (string, bool, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return "", fmt.Errorf("error opening file: %w", err)
+		return "", false, fmt.Errorf("error opening file: %w", err)
 	}
 	defer func(f *os.File) {
 		err := f.Close()
@@ -297,11 +295,12 @@ func DecodeTestJSONFileToString(fileName string) (string, error) {
 
 	var buf bytes.Buffer
 	dec := json.NewDecoder(f)
+	passed := true
 
 	for dec.More() {
 		var ev TestEvent
 		if err := dec.Decode(&ev); err != nil {
-			return "", fmt.Errorf("error decoding JSON: %w", err)
+			return "", false, fmt.Errorf("error decoding JSON: %w", err)
 		}
 
 		switch ev.Action {
@@ -314,13 +313,14 @@ func DecodeTestJSONFileToString(fileName string) (string, error) {
 		case "fail":
 			if ev.Test != "" {
 				_, _ = fmt.Fprintf(&buf, "--- FAIL: %s (%.2fs)\n", ev.Test, ev.Elapsed)
+				passed = false
 			}
 		case "output":
 			buf.WriteString(ev.Output)
 		}
 	}
 
-	return buf.String(), nil
+	return buf.String(), passed, nil
 }
 
 func createTestCasesFile(configuration *console.SentinelCheckIntegrationTestConfigurationFragment, cluster *console.SentinelRunJobFragment_Cluster) (string, error) {

--- a/pkg/sentinel-harness/controller/controller.go
+++ b/pkg/sentinel-harness/controller/controller.go
@@ -124,7 +124,7 @@ func (in *sentinelRunController) runTests(fragment *console.SentinelRunJobFragme
 	klog.V(log.LogLevelDefault).InfoS("running gotestsum", "args", args)
 
 	if err := cmd.Run("", args); err != nil {
-		klog.Warning("gotestsum returned an error", err)
+		klog.Warningf("gotestsum returned an error: %v", err)
 	}
 
 	output, passed, err := DecodeTestJSONFileToString(filepath.Join(in.outputDir, jsonFile))

--- a/pkg/sentinel-harness/controller/controller.go
+++ b/pkg/sentinel-harness/controller/controller.go
@@ -316,8 +316,8 @@ func DecodeTestJSONFileToString(fileName string) (string, bool, error) {
 		case "fail":
 			if ev.Test != "" {
 				_, _ = fmt.Fprintf(&buf, "--- FAIL: %s (%.2fs)\n", ev.Test, ev.Elapsed)
-				passed = false
 			}
+			passed = false
 		case "output":
 			buf.WriteString(ev.Output)
 		}

--- a/pkg/sentinel-harness/controller/controller_test.go
+++ b/pkg/sentinel-harness/controller/controller_test.go
@@ -1,6 +1,9 @@
 package controller
 
 import (
+	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 
 	console "github.com/pluralsh/console/go/client"
@@ -73,5 +76,101 @@ func mustNotContainArgPair(t *testing.T, args []string, key, value string) {
 		if args[idx] == key && args[idx+1] == value {
 			t.Fatalf("expected args to not contain pair %q %q, got: %v", key, value, args)
 		}
+	}
+}
+
+// Helper for writing temp JSON files for test events
+func writeTempJSONFile(t *testing.T, events []TestEvent) string {
+	t.Helper()
+	tmpfile, err := os.CreateTemp("", "testjson-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	enc := json.NewEncoder(tmpfile)
+	for _, ev := range events {
+		if err := enc.Encode(ev); err != nil {
+			t.Fatalf("failed to encode event: %v", err)
+		}
+	}
+	tmpfile.Close()
+	return tmpfile.Name()
+}
+
+func TestDecodeTestJSONFileToString_AllPass(t *testing.T) {
+	events := []TestEvent{
+		{Action: "run", Test: "TestFoo"},
+		{Action: "pass", Test: "TestFoo", Elapsed: 1.23},
+	}
+	file := writeTempJSONFile(t, events)
+	defer os.Remove(file)
+	output, passed, err := DecodeTestJSONFileToString(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !passed {
+		t.Errorf("expected passed=true, got false")
+	}
+	if !strings.Contains(output, "--- PASS: TestFoo (1.23s)") {
+		t.Errorf("output missing PASS line: %q", output)
+	}
+}
+
+func TestDecodeTestJSONFileToString_Fail(t *testing.T) {
+	events := []TestEvent{
+		{Action: "run", Test: "TestBar"},
+		{Action: "fail", Test: "TestBar", Elapsed: 2.34},
+	}
+	file := writeTempJSONFile(t, events)
+	defer os.Remove(file)
+	output, passed, err := DecodeTestJSONFileToString(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if passed {
+		t.Errorf("expected passed=false, got true")
+	}
+	if !strings.Contains(output, "--- FAIL: TestBar (2.34s)") {
+		t.Errorf("output missing FAIL line: %q", output)
+	}
+}
+
+func TestDecodeTestJSONFileToString_Mixed(t *testing.T) {
+	events := []TestEvent{
+		{Action: "run", Test: "TestA"},
+		{Action: "pass", Test: "TestA", Elapsed: 0.5},
+		{Action: "run", Test: "TestB"},
+		{Action: "fail", Test: "TestB", Elapsed: 1.5},
+	}
+	file := writeTempJSONFile(t, events)
+	defer os.Remove(file)
+	output, passed, err := DecodeTestJSONFileToString(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if passed {
+		t.Errorf("expected passed=false, got true")
+	}
+	if !strings.Contains(output, "--- PASS: TestA (0.50s)") || !strings.Contains(output, "--- FAIL: TestB (1.50s)") {
+		t.Errorf("output missing expected lines: %q", output)
+	}
+}
+
+func TestDecodeTestJSONFileToString_OutputLines(t *testing.T) {
+	events := []TestEvent{
+		{Action: "run", Test: "TestLog"},
+		{Action: "output", Test: "TestLog", Output: "hello\n"},
+		{Action: "pass", Test: "TestLog", Elapsed: 0.1},
+	}
+	file := writeTempJSONFile(t, events)
+	defer os.Remove(file)
+	output, passed, err := DecodeTestJSONFileToString(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !passed {
+		t.Errorf("expected passed=true, got false")
+	}
+	if !strings.Contains(output, "hello") {
+		t.Errorf("output missing log line: %q", output)
 	}
 }


### PR DESCRIPTION
 - derive status from the tests result
 - conditionally respect `integrationTestConfig.Default.Ignore`

The rest of Default fields  are already wired properly


## Test Plan
<!-- Please provide a link to a test environment where you have deployed and tested the agent. -->
Test environment: https://console.your-env.onplural.sh/

<!-- Please describe the tests you have added and preformed. -->

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have deployed the agent to a test environment and verified that it works as expected.
    - [ ] Agent starts successfully.
    - [ ] Service creation works without any issues when using raw manifests and Helm templates.
    - [ ] Service creation works when resources contain both CRD and CRD instances.
    - [ ] Service templating works correctly.
    - [ ] Service errors are reported properly and visible in the UI.
    - [ ] Service updates are reflected properly in the cluster.
    - [ ] Service resync triggers immediately and works as expected.
    - [ ] Sync waves annotations are respected.
    - [ ] Sync phases annotations are respected. Phases are executed in the correct order.
    - [ ] Sync hook delete policies are respected. Resources are not recreated once they reach the desired state.
    - [ ] Service deletion works and cleanups resources properly.
    - [ ] Services can be recreated after deletion.
    - [ ] Service detachment works and keeps resources unaffected.
    - [ ] Services can be recreated after detachment.
    - [ ] Service component trees are working as expected.
    - [ ] Cluster health statuses are being updated.
    - [ ] Agent logs do not contain any errors (after running for at least 30 minutes).
    - [ ] There are no visible anomalies in Datadog (after running for at least 30 minutes).
- [ ] I have added tests to cover my changes.
- [ ] If required, I have updated the Plural documentation accordingly.

