### PR TITLE
fix: stackrun job defaults

### DIFF
--- a/.github/workflows/publish-harness-fips.yaml
+++ b/.github/workflows/publish-harness-fips.yaml
@@ -140,19 +140,19 @@ jobs:
         versions:
         - ansible: '7.7.0'
           python: '3.11'
-          tag: '7.7'
+          minor: '7.7'
         - ansible: '8.7.0'
           python: '3.11'
-          tag: '8.7'
+          minor: '8.7'
         - ansible: '9.0.1'
           python: '3.12'
-          tag: '9.0'
+          minor: '9.0'
         - ansible: '10.0.1'
           python: '3.12'
-          tag: '10.0'
+          minor: '10.0'
         - ansible: '11.0.0'
           python: '3.12'
-          tag: '11.0'
+          minor: '11.0'
     permissions:
       contents: write
       discussions: write
@@ -171,9 +171,12 @@ jobs:
           ghcr.io/pluralsh/harness
           docker.io/pluralsh/harness
         tags: |
-          type=semver,pattern={{version}},suffix=-ansible-${{ matrix.versions.tag }}-fips,priority=1000
-          type=sha,suffix=-ansible-${{ matrix.versions.tag }}-fips,priority=800
-          type=ref,event=pr,suffix=-ansible-${{ matrix.versions.tag }}-fips,priority=600
+          type=semver,pattern={{version}},suffix=-ansible-${{ matrix.versions.ansible }}-fips,priority=1000
+          type=semver,pattern={{version}},suffix=-ansible-${{ matrix.versions.minor }}-fips,priority=1000
+          type=sha,suffix=-ansible-${{ matrix.versions.ansible }}-fips,priority=800
+          type=sha,suffix=-ansible-${{ matrix.versions.minor }}-fips,priority=800
+          type=ref,event=pr,suffix=-ansible-${{ matrix.versions.ansible }}-fips,priority=600
+          type=ref,event=pr,suffix=-ansible-${{ matrix.versions.minor }}-fips,priority=600
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx

--- a/.github/workflows/publish-harness.yaml
+++ b/.github/workflows/publish-harness.yaml
@@ -138,37 +138,35 @@ jobs:
       matrix:
         versions:
         - full: 1.14.9
-          tag: 1.14.9
-        - full: 1.14.9
-          tag: "1.14"
+          minor: "1.14"
         - full: 1.13.5
-          tag: '1.13'
+          minor: "1.13"
         - full: 1.12.2
-          tag: '1.12'
+          minor: "1.12"
         - full: 1.11.4
-          tag: "1.11"
+          minor: "1.11"
         - full: 1.10.5
-          tag: '1.10'
+          minor: "1.10"
         - full: 1.9.8
-          tag: '1.9'
+          minor: "1.9"
         - full: 1.8.2
-          tag: "1.8"
+          minor: "1.8"
         - full: 1.7.5
-          tag: '1.7'
+          minor: "1.7"
         - full: 1.6.6
-          tag: '1.6'
+          minor: "1.6"
         - full: 1.5.7
-          tag: '1.5'
+          minor: "1.5"
         - full: 1.4.7
-          tag: '1.4'
+          minor: "1.4"
         - full: 1.3.10
-          tag: '1.3'
+          minor: "1.3"
         - full: 1.2.9
-          tag: '1.2'
+          minor: "1.2"
         - full: 1.1.9
-          tag: '1.1'
+          minor: "1.1"
         - full: 1.0.11
-          tag: '1.0'
+          minor: "1.0"
     permissions:
       contents: write
       discussions: write
@@ -188,9 +186,12 @@ jobs:
           ghcr.io/pluralsh/harness
           docker.io/pluralsh/harness
         tags: |
-          type=semver,pattern={{version}},suffix=-terraform-${{ matrix.versions.tag }},priority=1000
-          type=sha,suffix=-terraform-${{ matrix.versions.tag }},priority=800
-          type=ref,event=pr,suffix=-terraform-${{ matrix.versions.tag }},priority=600
+          type=semver,pattern={{version}},suffix=-terraform-${{ matrix.versions.full }},priority=1000
+          type=semver,pattern={{version}},suffix=-terraform-${{ matrix.versions.minor }},priority=1000
+          type=sha,suffix=-terraform-${{ matrix.versions.full }},priority=800
+          type=sha,suffix=-terraform-${{ matrix.versions.minor }},priority=800
+          type=ref,event=pr,suffix=-terraform-${{ matrix.versions.full }},priority=600
+          type=ref,event=pr,suffix=-terraform-${{ matrix.versions.minor }},priority=600
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -231,28 +232,28 @@ jobs:
         versions:
         - ansible: '4.10.0'
           python: '3.9'
-          tag: '4.10'
+          minor: '4.10'
         - ansible: '5.7.0'
           python: '3.10'
-          tag: '5.7'
+          minor: '5.7'
         - ansible: '6.7.0'
           python: '3.10'
-          tag: '6.7'
+          minor: '6.7'
         - ansible: '7.7.0'
           python: '3.11'
-          tag: '7.7'
+          minor: '7.7'
         - ansible: '8.7.0'
           python: '3.11'
-          tag: '8.7'
+          minor: '8.7'
         - ansible: '9.0.1'
           python: '3.12'
-          tag: '9.0'
+          minor: '9.0'
         - ansible: '10.0.1'
           python: '3.12'
-          tag: '10.0'
+          minor: '10.0'
         - ansible: '11.0.0'
           python: '3.12'
-          tag: '11.0'
+          minor: '11.0'
     permissions:
       contents: write
       discussions: write
@@ -271,9 +272,12 @@ jobs:
           ghcr.io/pluralsh/harness
           docker.io/pluralsh/harness
         tags: |
-          type=semver,pattern={{version}},suffix=-ansible-${{ matrix.versions.tag }},priority=1000
-          type=sha,suffix=-ansible-${{ matrix.versions.tag }},priority=800
-          type=ref,event=pr,suffix=-ansible-${{ matrix.versions.tag }},priority=600
+          type=semver,pattern={{version}},suffix=-ansible-${{ matrix.versions.ansible }},priority=1000
+          type=semver,pattern={{version}},suffix=-ansible-${{ matrix.versions.minor }},priority=1000
+          type=sha,suffix=-ansible-${{ matrix.versions.ansible }},priority=800
+          type=sha,suffix=-ansible-${{ matrix.versions.minor }},priority=800
+          type=ref,event=pr,suffix=-ansible-${{ matrix.versions.ansible }},priority=600
+          type=ref,event=pr,suffix=-ansible-${{ matrix.versions.minor }},priority=600
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx

--- a/internal/controller/stackrunjob_job.go
+++ b/internal/controller/stackrunjob_job.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	stackRunDefaultContainerVersions = map[console.StackType]string{
-		console.StackTypeTerraform: "1.8.2",
+		console.StackTypeTerraform: "1.8",
 		console.StackTypeAnsible:   "latest",
 	}
 
@@ -288,32 +288,21 @@ func (r *StackRunJobReconciler) ensureDefaultContainerSecurityContext(sc *corev1
 }
 
 func (r *StackRunJobReconciler) getDefaultContainerImage(run *console.StackRunMinimalFragment) string {
-	// In case image is not provided, it will use our default image.
-	// Image name format: <defaultImage>:<tag>
-	// Note: User has to make sure that the tag is correct and matches our naming scheme.
-	//
-	// In case image is provided, it will replace both image and tag with provided values.
-	// Image name format: <image>:<tag>
+	// Explicit docker tag (overrides the composite tag suffix below).
+	// Format: <imageOrDefault>:<tag>
 	if r.hasCustomTag(run) {
 		return fmt.Sprintf("%s:%s", r.getImage(run), *run.Configuration.Tag)
 	}
 
-	// In case there is a custom version and a custom image provided, it will replace both image and version
-	// with provided values.
-	// Image name format: <image>:<version>
+	// Pin tool semver as the full docker tag (optional escape hatch when both are set).
+	// Format: <image>:<version>
 	if r.hasCustomImage(run) && r.hasCustomVersion(run) {
 		return fmt.Sprintf("%s:%s", *run.Configuration.Image, *run.Configuration.Version)
 	}
 
-	// In case only image is provided, do not follow our default naming scheme.
-	// Image name format: <image>:<defaultTag>
-	// Note: User has to make sure that the image contains the tag matching our defaults.
-	if r.hasCustomImage(run) {
-		return fmt.Sprintf("%s:%s", *run.Configuration.Image, r.getTag(run))
-	}
-
-	// In any other case return image in the default format: <defaultImage>:<defaultTag>-<stackType>-<defaultVersionOrVersion>.
-	// In this case only a custom tool version is ever provided to override our defaults.
+	// Default tag shape: <patchTag>-<stackType>-<toolVersion>
+	// Applies to the stock image, a custom `image` (repository override only), custom `version`, or any mix that
+	// did not match the branches above.
 	return fmt.Sprintf("%s:%s-%s-%s", r.getImage(run), r.getTag(run), strings.ToLower(string(run.Type)), r.getVersion(run))
 }
 

--- a/internal/controller/stackrunjob_job_test.go
+++ b/internal/controller/stackrunjob_job_test.go
@@ -37,7 +37,7 @@ func TestGetDefaultContainerImage(t *testing.T) {
 				Type:          console.StackTypeTerraform,
 				Configuration: console.StackConfigurationFragment{},
 			},
-			expectedImage: "ghcr.io/pluralsh/harness:0.6.18-terraform-1.8.2",
+			expectedImage: "ghcr.io/pluralsh/harness:0.6.18-terraform-1.8",
 		},
 		{
 			name: "custom_tool_version_provided",
@@ -78,7 +78,7 @@ func TestGetDefaultContainerImage(t *testing.T) {
 					Image: lo.ToPtr("ghcr.io/pluralsh/custom"),
 				},
 			},
-			expectedImage: "ghcr.io/pluralsh/custom:0.6.18",
+			expectedImage: "ghcr.io/pluralsh/custom:0.6.18-terraform-1.8",
 		},
 		{
 			name: "custom_image_and_version_provided",
@@ -244,7 +244,7 @@ func genDefaultJobSpec(namespace, name, runID string) batchv1.JobSpec {
 				Containers: []corev1.Container{
 					{
 						Name:       defaultName,
-						Image:      "ghcr.io/pluralsh/harness:0.6.18-terraform-1.8.2",
+						Image:      "ghcr.io/pluralsh/harness:0.6.18-terraform-1.8",
 						WorkingDir: "",
 						EnvFrom: []corev1.EnvFromSource{
 							{

--- a/test/mixed/kustomize/liquid/dev/kustomization.yaml
+++ b/test/mixed/kustomize/liquid/dev/kustomization.yaml
@@ -11,7 +11,7 @@ nameSuffix: -dev
 configMapGenerator:
   - literals:
       - username=demo-user
-    name: 
+    name: nginx
 
 secretGenerator:
   - literals:

--- a/test/mixed/raw/pod.yaml
+++ b/test/mixed/raw/pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: 
+  name: nginx
 spec:
   containers:
     - name: nginx


### PR DESCRIPTION
Was using the full 1.8.2 version when it should just be 1.8

## Test Plan
<!-- Please provide a link to a test environment where you have deployed and tested the agent. -->
Test environment: https://console.plrldemo.onplural.sh/cd/clusters/a1748282-ce8b-48ab-ae7e-326e74fce04e/services/f3f89a54-d1a7-4bc8-9152-daa07ede918d/components

<!-- Please describe the tests you have added and preformed. -->

## Checklist
<!-- Go over all the following points to make sure you've checked all that apply before merging. -->
<!-- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have deployed the agent to a test environment and verified that it works as expected.
    - [x] Agent starts successfully.
    - [x] Service creation works without any issues when using raw manifests and Helm templates.
    - [x] Service creation works when resources contain both CRD and CRD instances.
    - [x] Service templating works correctly.
    - [x] Service errors are reported properly and visible in the UI.
    - [x] Service updates are reflected properly in the cluster.
    - [x] Service resync triggers immediately and works as expected.
    - [x] Sync waves annotations are respected.
    - [x] Sync phases annotations are respected. Phases are executed in the correct order.
    - [x] Sync hook delete policies are respected. Resources are not recreated once they reach the desired state.
    - [x] Service deletion works and cleanups resources properly.
    - [x] Services can be recreated after deletion.
    - [x] Service detachment works and keeps resources unaffected.
    - [x] Services can be recreated after detachment.
    - [x] Service component trees are working as expected.
    - [x] Cluster health statuses are being updated.
    - [x] Agent logs do not contain any errors (after running for at least 30 minutes).
    - [x] There are no visible anomalies in Datadog (after running for at least 30 minutes).
- [x] I have added tests to cover my changes.
- [x] If required, I have updated the Plural documentation accordingly.

